### PR TITLE
Keep reference of all ad objects when parsed, and delete ad.nextWrapperURL when async parsing is done

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -49,9 +49,8 @@ class VASTParser
                 cb(null, response)
 
             for ad in response.ads
+                continue unless ad.nextWrapperURL?
                 do (ad) =>
-                    return unless ad.nextWrapperURL?
-
                     if parentURLs.length >= 10 or ad.nextWrapperURL in parentURLs
                         # Wrapper limit reached, as defined by the video player.
                         # Too many Wrapper responses have been received with no InLine response.


### PR DESCRIPTION
Currently ad.nextWrapperURL is not deleted when this url is parsed, so in complete(), the for loop still see ads with nextWrapperURL properties.

But, because the parsing is done asynchronously, we need to keep a trace of all ad objects in order to delete the property on the relevant ad object.
