### PR TITLE
Implement persistent storage for capping through localStorage

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -1,25 +1,59 @@
 VASTParser = require './parser.coffee'
+VASTUtil = require './util.coffee'
 
 class VASTClient
-    @totalCalls: 0 # TODO: make this persistent across requests
     @cappingFreeLunch: 0
     @cappingMinimumTimeInterval: 0
     @timeout: 0
 
     @get: (url, cb) ->
-        # TODO handle timeout
-        @totalCalls++
+        now = +new Date()
+
+        # Check totalCallsTimeout (first call + 1 hour), if older than now,
+        # reset totalCalls number, by this way the client will be eligible again
+        # for freelunch capping
+        if @totalCallsTimeout < now
+            @totalCalls = 1
+            @totalCallsTimeout = now + (60 * 60 * 1000)
+        else
+            @totalCalls++
 
         if @cappingFreeLunch >= @totalCalls
             cb(null)
             return
 
-        if new Date().getTime() - @lastSuccessfulAd < @cappingMinimumTimeInterval
+        if now - @lastSuccessfullAd < @cappingMinimumTimeInterval
             cb(null)
             return
 
-        VASTParser.parse url, (response) ->
-            @lastSuccessfulAd = new Date().getTime() # TODO: make this persistent across requests
+        # TODO: handle request timeout
+
+        VASTParser.parse url, (response) =>
             cb(response)
+
+
+    # 'Fake' static constructor
+    do ->
+        storage = VASTUtil.storage
+        defineProperty = Object.defineProperty
+
+        # Create new properties for VASTClient, using ECMAScript 5
+        # we can define custom getters and setters logic.
+        # By this way, we implement the use of storage inside these methods,
+        # while it will be fully transparent for the user
+        ['lastSuccessfullAd', 'totalCalls', 'totalCallsTimeout'].forEach (property) ->
+            defineProperty VASTClient, property,
+            {
+                get: () -> storage.getItem property
+                set: (value) -> storage.setItem property, value
+                configurable: false
+                enumerable: true
+            }
+            return
+
+        # Init values if not already set
+        VASTClient.totalCalls ?= 0
+        VASTClient.totalCallsTimeout ?= 0
+        return
 
 module.exports = VASTClient

--- a/src/tracker.coffee
+++ b/src/tracker.coffee
@@ -1,3 +1,4 @@
+VASTClient = require('./client.coffee')
 VASTUtil = require('./util.coffee')
 VASTCreativeLinear = require('./creative.coffee').VASTCreativeLinear
 EventEmitter = require('events').EventEmitter
@@ -20,6 +21,10 @@ class VASTTracker extends EventEmitter
         else
             @skipDelay = -1
             @linear = no
+
+        @on 'start', ->
+            VASTClient.lastSuccessfullAd = +new Date()
+            return
 
     setProgress: (progress) ->
         if @skipDelay != -1 and not @skipable
@@ -98,6 +103,7 @@ class VASTTracker extends EventEmitter
     track: (eventName) ->
         trackingURLTemplates = @trackingEvents[eventName]
         if trackingURLTemplates?
+            @emit eventName, ''
             @trackURLs trackingURLTemplates
 
     trackURLs: (URLTemplates, variables) ->

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -26,4 +26,30 @@ class VASTUtil
 
         return URLs
 
+    @storage: do () ->
+        storage = if window? then window.localStorage or window.sessionStorage else null
+
+        if not storage?
+            data = {}
+            storage = {
+                length: 0
+                getItem: (key) ->
+                    return data[key]
+                setItem: (key, value) ->
+                    data[key] = value
+                    @length = Object.keys(data).length
+                    return
+                removeItem: (key) ->
+                    delete data[key]
+                    @length = Object.keys(data).length
+                    return
+                clear: () ->
+                    data = {}
+                    @length = 0
+                    return
+            }
+
+        return storage
+
+
 module.exports = VASTUtil

--- a/test/storage.coffee
+++ b/test/storage.coffee
@@ -1,0 +1,56 @@
+should = require 'should'
+path = require 'path'
+VASTUtil = require '../src/util'
+VASTClient = require '../src/client'
+
+urlfor = (relpath) ->
+    return 'file://' + path.resolve(path.dirname(module.filename), relpath)
+
+describe 'VASTClient Storage', ->
+    wrapperUrl = urlfor('wrapper.xml')
+    totalCallsTimeout = null
+
+    describe '#1st call', ->
+        VASTClient.cappingFreeLunch = 1
+
+        it 'should be null', (done) =>
+            VASTClient.get wrapperUrl, (response) =>
+                totalCallsTimeout = VASTClient.totalCallsTimeout
+                if response is null then done()
+                else throw '1st response is not blank'
+
+        it 'VASTClient.totalCalls should be equal to 1', () =>
+            VASTClient.totalCalls.should.eql 1
+
+
+    describe '#2nd call', ->
+        it "shouldn't be null", (done) =>
+            VASTClient.get wrapperUrl, (response) =>
+                if response isnt null then done()
+                else throw '2nd response is blank'
+
+        it 'VASTClient.totalCalls should be equal to 2', () =>
+            VASTClient.totalCalls.should.eql 2
+
+
+    describe '#3rd call', ->
+        it "shouldn't be null", (done) =>
+            VASTClient.get wrapperUrl, (response) =>
+                if response isnt null then done()
+                else throw '3rd response is blank'
+
+        it 'VASTClient.totalCalls should be equal to 3', () =>
+            VASTClient.totalCalls.should.eql 3
+
+        it 'VASTClient.totalCallsTimeout should be the same', () =>
+            VASTClient.totalCallsTimeout.should.eql totalCallsTimeout
+
+
+    describe '#4th call', ->
+        it "4th request should be null", (done) =>
+            console.log 'Resetting totalCallsTimeout'
+            VASTClient.totalCallsTimeout = 0
+
+            VASTClient.get wrapperUrl, (response) =>
+                if response is null then done()
+                else throw '4th response is not blank'


### PR DESCRIPTION
- Create VASTUtil.storage: binds to localStorage or sessionStorage if available, fallback to a very simple polyfill (only save in current session, in a basic JavaScript object)
- Use storage to save totalCalls, totalCallsTimeout, lastSuccessfullAd
- lastSuccessfullAd is set when 'start' event is triggered
