### PR TITLE
localStorage is read only when private browsing is ON in Safari (Mac + iOS) 

### DIFF
--- a/src/util.coffee
+++ b/src/util.coffee
@@ -29,7 +29,20 @@ class VASTUtil
     @storage: do () ->
         storage = if window? then window.localStorage or window.sessionStorage else null
 
-        if not storage?
+        # In Safari (Mac + iOS) when private browsing is ON,
+        # localStorage is read only
+        # http://spin.atomicobject.com/2013/01/23/ios-private-browsing-localstorage/
+        isDisabled = (store) ->
+            try
+                testValue = '__VASTUtil__'
+                store.setItem testValue, testValue
+                return yes if store.getItem(testValue) isnt testValue
+            catch e
+                return yes
+            return no
+
+
+        if not storage? or isDisabled(storage)
             data = {}
             storage = {
                 length: 0


### PR DESCRIPTION
I added a quick read/write test before enabling localStorage.
The fix is inspired from marcuswestin/store.js#66.

By the way, _store.js_ library seems to be more "bullet-proof" across browsers capabilities. I think it may be a good option to rely on it instead of starting from scratch.

What do you think?
