### PR TITLE
localStorage access crashes script in an iframe with third-party cookies blocked

### DIFF
--- a/src/util.coffee
+++ b/src/util.coffee
@@ -27,7 +27,10 @@ class VASTUtil
         return URLs
 
     @storage: do () ->
-        storage = if window? then window.localStorage or window.sessionStorage else null
+        try
+            storage = if window? then window.localStorage or window.sessionStorage else null
+        catch storageError
+            storage = null
 
         # In Safari (Mac + iOS) when private browsing is ON,
         # localStorage is read only


### PR DESCRIPTION
When third-party cookies are blocked and the script runs in an iframe, any reference to `window.localStorage` or `window.sessionStorage` throws an error, which breaks the script and anything that comes after it.
