### PR TITLE
Distinct 3 states for skipDelay: skipOffset not found -> skipDelay = def...

### DIFF
--- a/src/creative.coffee
+++ b/src/creative.coffee
@@ -7,7 +7,7 @@ class VASTCreativeLinear extends VASTCreative
         super
         @type = "linear"
         @duration = 0
-        @skipDelay = -1
+        @skipDelay = null
         @mediaFiles = []
         @videoClickThroughURLTemplate = null
         @videoClickTrackingURLTemplate = null

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -162,11 +162,12 @@ class VASTParser
             return null # can't parse duration, element is required
 
         skipOffset = creativeElement.getAttribute("skipoffset")
-        if skipOffset? and skipOffset[skipOffset.length - 1] is "%"
-            percent = parseInt(skipOffset)
-            creative.skipOffset = creative.duration * (percent / 100)
+        if not skipOffset? then creative.skipDelay = null
+        else if skipOffset.charAt(skipOffset.length - 1) is "%"
+            percent = parseInt(skipOffset, 10)
+            creative.skipDelay = creative.duration * (percent / 100)
         else
-            creative.skipOffset = @parseDuration skipOffset
+            creative.skipDelay = @parseDuration skipOffset
 
         videoClicksElement = @childByName(creativeElement, "VideoClicks")
         if videoClicksElement?

--- a/src/tracker.coffee
+++ b/src/tracker.coffee
@@ -8,6 +8,7 @@ class VASTTracker extends EventEmitter
         @muted = no
         @impressed = no
         @skipable = no
+        @skipDelayDefault = -1
         @trackingEvents = {}
         # Duplicate the creative's trackingEvents property so we can alter it
         for eventName, events of creative.trackingEvents
@@ -27,9 +28,11 @@ class VASTTracker extends EventEmitter
             return
 
     setProgress: (progress) ->
-        if @skipDelay != -1 and not @skipable
-            if @skipDelay > progress
-                @emit 'skip-countdown', @skipDelay - progress
+        skipDelay = if @skipDelay is null then @skipDelayDefault else @skipDelay
+
+        if skipDelay != -1 and not @skipable
+            if skipDelay > progress
+                @emit 'skip-countdown', skipDelay - progress
             else
                 @skipable = yes
                 @emit 'skip-countdown', 0
@@ -72,6 +75,9 @@ class VASTTracker extends EventEmitter
         if @fullscreen != fullscreen
             @track(if fullscreen then "fullscreen" else "exitFullscreen")
         @fullscreen = fullscreen
+
+    setSkipDelay: (duration) ->
+        @skipDelay = duration if typeof duration is 'number'
 
     load: ->
         unless @impressed


### PR DESCRIPTION
Distinct 3 states for skipDelay: 
- skipOffset attribute not found --> skipDelay = null
- skipOffset = -1 --> ad not skipable
- skipOffset = number --> skipDelay = skipOffset

We don't touch the creative.skipDelay property in the VASTTracker constructor, because we want to let the possibility to override the skipDelay manually via the VASTTracker.setSkipDelay().

By default, if no skipDelay is found and the skipDelay is not overridden, we act like the VAST spec (linear creative non skipable).
