### PR TITLE
Stop ignoring `bower.json` in `bower.json`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,6 @@
         "components",
         "src",
         "test",
-        "package.json",
-        "bower.json"
+        "package.json"
     ]
 }


### PR DESCRIPTION
Ignoring `bower.json` in the `bower.json` file makes it really tricky to install `vast-client` with Bower as a dependency in a Rails project - Sprockets expects the `bower.json` file so it can make use of the main entry point declaration.
