### PR TITLE
Fixed tracking for ClickThrough URL

### DIFF
--- a/src/tracker.coffee
+++ b/src/tracker.coffee
@@ -110,7 +110,7 @@ class VASTTracker extends EventEmitter
 
     click: ->
         if @clickTrackingURLTemplate?
-            @trackURLs @clickTrackingURLTemplate
+            @trackURLs [@clickTrackingURLTemplate]
 
         if @clickThroughURLTemplate?
             if @linear


### PR DESCRIPTION
VASTTracker:trackURLs should be called with an array, otherwise tracker will try to ping every single character of the given `@clickTrackingURLTemplate`
