### PR TITLE
 Version 1.1.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "vast-client-js",
     "author": ["Olivier Poitrey <rs@dailymotion.com>"],
-    "version": "1.1.1",
+    "version": "1.1.2",
     "main": "vast-client.js",
     "licenses": [{"type": "MIT", "url": "https://github.com/rs/vast-client-js/raw/master/LICENSE"}],
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vast-client-js",
     "author": "Olivier Poitrey <rs@dailymotion.com>",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Javascript VAST Client",
     "keywords": ["vast", "ad", "advertising", "iab", "in-stream", "video"],
     "repository": {"type": "git", "url": "https://github.com/rs/vast-client-js"},

--- a/vast-client.js
+++ b/vast-client.js
@@ -542,7 +542,7 @@ VASTTracker = (function(_super) {
   VASTTracker.prototype.click = function() {
     var clickThroughURL, variables;
     if (this.clickTrackingURLTemplate != null) {
-      this.trackURLs(this.clickTrackingURLTemplate);
+      this.trackURLs([this.clickTrackingURLTemplate]);
     }
     if (this.clickThroughURLTemplate != null) {
       if (this.linear) {
@@ -984,6 +984,23 @@ module.exports = {
   VASTCreativeCompanion: VASTCreativeCompanion
 };
 
+},{}],11:[function(require,module,exports){
+var VASTAd;
+
+VASTAd = (function() {
+
+  function VASTAd() {
+    this.errorURLTemplates = [];
+    this.impressionURLTemplates = [];
+    this.creatives = [];
+  }
+
+  return VASTAd;
+
+})();
+
+module.exports = VASTAd;
+
 },{}],10:[function(require,module,exports){
 var VASTResponse;
 
@@ -1022,23 +1039,6 @@ VASTMediaFile = (function() {
 })();
 
 module.exports = VASTMediaFile;
-
-},{}],11:[function(require,module,exports){
-var VASTAd;
-
-VASTAd = (function() {
-
-  function VASTAd() {
-    this.errorURLTemplates = [];
-    this.impressionURLTemplates = [];
-    this.creatives = [];
-  }
-
-  return VASTAd;
-
-})();
-
-module.exports = VASTAd;
 
 },{}],9:[function(require,module,exports){
 var URLHandler, flash, xhr;


### PR DESCRIPTION
- Update vast-client.js to the lastest master
- Bump version number to 1.1.2

_Note_: bower registry needs a `1.1.2` tag. Thx.
