### PR TITLE
Added Resume and Pause to the have-to-sent-in-any-case events list

### DIFF
--- a/src/tracker.coffee
+++ b/src/tracker.coffee
@@ -15,7 +15,7 @@ class VASTTracker extends EventEmitter
         @emitAlwaysEvents = [
             'creativeView',
             'start', 'firstQuartile', 'midpoint', 'thirdQuartile', 'complete',
-            'rewind', 'skip', 'closeLinear', 'close'
+            'resume', 'pause', 'rewind', 'skip', 'closeLinear', 'close'
         ]
         # Duplicate the creative's trackingEvents property so we can alter it
         for eventName, events of creative.trackingEvents


### PR DESCRIPTION
Fix a bug where resume/pause events aren't emitted if they weren't defined as trackingEvents in VAST file.
