### PR TITLE
Fix trackingEvents when Wrapper contains a Companion

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -140,7 +140,12 @@ class VASTParser
         if wrapperURLElement?
             ad.nextWrapperURL = @parseNodeText wrapperURLElement
 
-        wrapperCreativeElement = ad.creatives[0]
+        wrapperCreativeElement = null
+        for creative in ad.creatives
+            if creative.type is 'linear'
+                wrapperCreativeElement = creative
+                break
+
         if wrapperCreativeElement? and wrapperCreativeElement.trackingEvents?
             ad.trackingEvents = wrapperCreativeElement.trackingEvents
 

--- a/test/wrapper.xml
+++ b/test/wrapper.xml
@@ -9,6 +9,15 @@
       <Impression>http://example.com/wrapper-impression</Impression>
       <Creatives>
         <Creative>
+          <CompanionAds>
+            <Companion id="urn:a2:287461:103" width="0" height="0">
+              <CompanionClickThrough><![CDATA[http://example.com/companion-click-thru]]></CompanionClickThrough>
+              <CompanionClickTracking><![CDATA[http://example.com/companion-click-tracking]]></CompanionClickTracking>
+              <AdParameters><![CDATA[campaign_id=10446]]></AdParameters>
+            </Companion>
+          </CompanionAds>
+        </Creative>
+        <Creative>
           <Linear>
             <TrackingEvents>
               <Tracking event="start"><![CDATA[http://example.com/wrapper-start]]></Tracking>


### PR DESCRIPTION
Some tracking events were missing when a `<CompanionAds>` creative is present before the `<Linear>` creative in a wrapper.
- Update `parseWrapperElement` method to always use a linear creative before searchng for `trackingEvents`
- Update `wrapper.xml` with more complex VAST (unit tests break without the fix)
