### PR TITLE
don't try to resolve invalid urls

### DIFF
--- a/src/util.coffee
+++ b/src/util.coffee
@@ -18,6 +18,7 @@ class VASTUtil
 
         for URLTemplate in URLTemplates
             resolveURL = URLTemplate
+            continue unless resolveURL
             for key, value of variables
                 macro1 = "[#{key}]"
                 macro2 = "%%#{key}%%"

--- a/test/util.coffee
+++ b/test/util.coffee
@@ -20,3 +20,6 @@ describe 'VASTUtil', ->
 
         it 'should resolve weird cases', ->
             resolve("http://test.com/%%CONTENTPLAYHEAD%%&[CONTENTPLAYHEAD]", CONTENTPLAYHEAD: 120).should.equal "http://test.com/120&120"
+
+        it 'should handle undefined', ->
+            should(resolve(undefined)).equal undefined


### PR DESCRIPTION
- some of our partners send vast with empty impression- and/or error-tracking urls
- we could also make sure urls are valid before adding them to the respective arrays but this here seems simpler
