### PR TITLE
adding withCrendentials=true to xhr

### DIFF
--- a/src/urlhandlers/xmlhttprequest.coffee
+++ b/src/urlhandlers/xmlhttprequest.coffee
@@ -10,6 +10,7 @@ class XHRURLHandler
     @get: (url, cb) ->
         xhr = @xhr()
         xhr.open('GET', url)
+        xhr.withCredentials = true
         xhr.send()
         xhr.onreadystatechange = ->
             if xhr.readyState == 4


### PR DESCRIPTION
We having issues with MacOsX/Safari not being able to retrieve VAST from our server without this setting. Chrome and Firefox seem to work fine without it.

thanks in advance for looking into this.
