### PR TITLE
catching xhr-errors

### DIFF
--- a/src/urlhandlers/xmlhttprequest.coffee
+++ b/src/urlhandlers/xmlhttprequest.coffee
@@ -8,11 +8,14 @@ class XHRURLHandler
         return !!@xhr()
 
     @get: (url, cb) ->
-        xhr = @xhr()
-        xhr.open('GET', url)
-        xhr.send()
-        xhr.onreadystatechange = ->
-            if xhr.readyState == 4
-                cb(null, xhr.responseXML)
+        try
+            xhr = @xhr()
+            xhr.open('GET', url)
+            xhr.send()
+            xhr.onreadystatechange = ->
+                if xhr.readyState == 4
+                    cb(null, xhr.responseXML)
+        catch
+            cb()
 
 module.exports = XHRURLHandler


### PR DESCRIPTION
in FF, the adblocker extension blocks requests so that the onreadystatechange-handler is never called but an error is thrown.
