### PR TITLE
extend VASTParser to emit 'VAST-error' event

### DIFF
--- a/test/empty.xml
+++ b/test/empty.xml
@@ -1,0 +1,1 @@
+<VAST version="2.0"/>

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -131,3 +131,30 @@ describe 'VASTParser', ->
                 @response.ads[0].creatives[0].mediaFiles[0].apiFramework.should.be.equal "VPAID"
 
 
+    describe '#track', ->
+        errorCallbackCalled = 0
+        errorCode = null
+        errorCallback = (ec) ->
+            errorCallbackCalled++
+            errorCode = ec
+
+        beforeEach =>
+            VASTParser.vent.removeAllListeners()
+            errorCallbackCalled = 0
+
+        #No ads VAST response after one wrapper
+        it 'emits an VAST-error on empty vast directly', (done) ->
+            VASTParser.on 'VAST-error', errorCallback
+            VASTParser.parse urlfor('empty.xml'), =>
+                errorCallbackCalled.should.equal 1
+                errorCode.ERRORCODE.should.eql 303
+                done()
+
+        #No ads VAST response after more than one wrapper
+        it 'emits 3 VAST-error events on empty vast after one wrapper', (done) ->
+            VASTParser.on 'VAST-error', errorCallback
+            VASTParser.parse urlfor('wrapper-empty.xml'), =>
+                errorCallbackCalled.should.equal 3
+                errorCode.ERRORCODE.should.eql 303
+                done()
+

--- a/test/wrapper-empty.xml
+++ b/test/wrapper-empty.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<VAST version="2.0">
+  <Error><![CDATA[http://example.com/wrapper-error]]></Error>
+  <Ad>
+    <Wrapper>
+      <AdSystem>VAST</AdSystem>
+      <VASTAdTagURI>empty.xml</VASTAdTagURI>
+      <Error>http://example.com/wrapper-error</Error>
+      <Impression>http://example.com/wrapper-impression</Impression>
+      <Creatives>
+        <Creative>
+          <CompanionAds>
+            <Companion id="urn:a2:287461:103" width="0" height="0">
+              <CompanionClickThrough><![CDATA[http://example.com/companion-click-thru]]></CompanionClickThrough>
+              <CompanionClickTracking><![CDATA[http://example.com/companion-click-tracking]]></CompanionClickTracking>
+              <AdParameters><![CDATA[campaign_id=10446]]></AdParameters>
+            </Companion>
+          </CompanionAds>
+        </Creative>
+        <Creative>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start"><![CDATA[http://example.com/wrapper-start]]></Tracking>
+              <Tracking event="complete"><![CDATA[http://example.com/wrapper-complete]]></Tracking>
+            </TrackingEvents>
+            <VideoClicks>
+              <ClickTracking><![CDATA[http://example.com/wrapper-clicktracking]]></ClickTracking>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </Wrapper>
+  </Ad>
+</VAST>


### PR DESCRIPTION
VASTParser now has an instance of EventEmitter. It exposes 

```
on: (eventName, cb) ->
once: (eventName, cb) ->
```

So you can do

```
VASTParser.on 'VAST-error', (error) -> console.log 'Vast-error occured', error.ERRORCODE
```

what do you think? 
