### PR TITLE
Options parameter

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -6,8 +6,13 @@ class VASTClient
     @cappingMinimumTimeInterval: 0
     @timeout: 0
 
-    @get: (url, cb) ->
+    @get: (url, opts, cb) ->
         now = +new Date()
+        options = {}
+        
+        if opts
+          options = opts if typeof opts is 'object'
+          cb = opts if typeof opts is 'function'
 
         # Check totalCallsTimeout (first call + 1 hour), if older than now,
         # reset totalCalls number, by this way the client will be eligible again
@@ -28,7 +33,7 @@ class VASTClient
 
         # TODO: handle request timeout
 
-        VASTParser.parse url, (response) =>
+        VASTParser.parse url, options, (response) =>
             cb(response)
 
 

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -19,8 +19,12 @@ class VASTParser
     @countURLTemplateFilters: () -> URLTemplateFilters.length
     @clearUrlTemplateFilters: () -> URLTemplateFilters = []
 
-    @parse: (url, cb) ->
-        @_parse url, null, (err, response) ->
+    @parse: (url, options, cb) ->
+        if typeof options is 'function'
+          cb = options
+          options = null
+        
+        @_parse url, null, options, (err, response) ->
             cb(response)
 
     @vent = new EventEmitter()
@@ -34,7 +38,7 @@ class VASTParser
     @once: (eventName, cb) ->
         @vent.once eventName, cb
 
-    @_parse: (url, parentURLs, cb) ->
+    @_parse: (url, parentURLs, options, cb) ->
 
         # Process url with defined filter
         url = filter(url) for filter in URLTemplateFilters
@@ -42,7 +46,13 @@ class VASTParser
         parentURLs ?= []
         parentURLs.push url
 
-        URLHandler.get url, (err, xml) =>
+        if typeof options is 'function'
+          cb = options
+          options = {}
+          
+        options = {} if not options
+        
+        URLHandler.get url, options, (err, xml) =>
             return cb(err) if err?
 
             response = new VASTResponse()

--- a/src/urlhandler.coffee
+++ b/src/urlhandler.coffee
@@ -2,14 +2,14 @@ xhr = require './urlhandlers/xmlhttprequest.coffee'
 flash = require './urlhandlers/flash.coffee'
 
 class URLHandler
-    @get: (url, cb) ->
+    @get: (url, options, cb) ->
         if not window?
             # prevents browserify from including this file
-            return require('./urlhandlers/' + 'node.coffee').get(url, cb)
+            return require('./urlhandlers/' + 'node.coffee').get(url, options, cb)
         else if xhr.supported()
-            return xhr.get(url, cb)
+            return xhr.get(url, options, cb)
         else if flash.supported()
-            return flash.get(url, cb)
+            return flash.get(url, options, cb)
         else
             return cb()
 

--- a/src/urlhandlers/flash.coffee
+++ b/src/urlhandlers/flash.coffee
@@ -6,7 +6,11 @@ class FlashURLHandler
     @supported: ->
         return !!@xdr()
 
-    @get: (url, cb) ->
+    @get: (url, options, cb) ->
+        if typeof options is 'function'
+          cb = options
+          options = null
+
         if xmlDocument = new window.ActiveXObject? "Microsoft.XMLDOM"
           xmlDocument.async = false
         else
@@ -14,6 +18,7 @@ class FlashURLHandler
 
         xdr = @xdr()
         xdr.open('GET', url)
+        xdr.withCredentials = true if options and options.withCredentials is true
         xdr.send()
         xdr.onload = ->
              xmlDocument.loadXML(xdr.responseText)

--- a/src/urlhandlers/node.coffee
+++ b/src/urlhandlers/node.coffee
@@ -4,7 +4,12 @@ http = require 'http'
 DOMParser = require('xmldom').DOMParser
 
 class NodeURLHandler
-    @get: (url, cb) ->
+    @get: (url, options, cb) ->
+        if typeof options is 'function'
+          cb = options
+          options = null
+        
+    
         url = uri.parse(url)
         if url.protocol is 'file:'
             fs.readFile url.pathname, 'utf8', (err, data) ->

--- a/src/urlhandlers/xmlhttprequest.coffee
+++ b/src/urlhandlers/xmlhttprequest.coffee
@@ -7,10 +7,15 @@ class XHRURLHandler
     @supported: ->
         return !!@xhr()
 
-    @get: (url, cb) ->
+    @get: (url, options, cb) ->
+        if typeof options is 'function'
+          cb = options
+          options = null
+        
         try
             xhr = @xhr()
             xhr.open('GET', url)
+            xhr.withCredentials = true if options and options.withCredentials is true
             xhr.send()
             xhr.onreadystatechange = ->
                 if xhr.readyState == 4


### PR DESCRIPTION
+ Provides the optional `options` parameter to `.get()` methods.
Currently the only option available is `withCredentials` for XHR.

+ Provides support for `withCredentials` on XHR libraries, in order to allow browsers to pass cookies on.

Usage example: `vast.client.get(url, {'withCredentials': true}, cb)`