### PR TITLE
Fix xdr Bug

### DIFF
--- a/src/urlhandlers/flash.coffee
+++ b/src/urlhandlers/flash.coffee
@@ -18,6 +18,8 @@ class FlashURLHandler
         xdr.timeout = options.timeout or 0
         xdr.withCredentials = options.withCredentials or false
         xdr.send()
+        xdr.onprogress = ->
+
         xdr.onload = ->
              xmlDocument.loadXML(xdr.responseText)
              cb(null, xmlDocument)


### PR DESCRIPTION
xdr.onpregress always defined, here a thread about this bug 

http://bugs.jquery.com/ticket/8283.

Here ref on MSDN 

https://social.msdn.microsoft.com/Forums/ie/en-US/30ef3add-767c-4436-b8a9-f1ca19b4812e/ie9-rtm-xdomainrequest-issued-requests-may-abort-if-all-event-handlers-not-specified?forum=iewebdevelopment