### PR TITLE
Make unit tests running correctly on Windows environment

### DIFF
--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -4,7 +4,7 @@ VASTParser = require '../src/parser'
 VASTResponse = require '../src/response'
 
 urlfor = (relpath) ->
-    return 'file://' + path.resolve(path.dirname(module.filename), relpath)
+    return 'file://' + path.resolve(path.dirname(module.filename), relpath).replace(/\\/g, '/')
 
 describe 'VASTParser', ->
     describe '#parse', ->

--- a/test/storage.coffee
+++ b/test/storage.coffee
@@ -4,7 +4,7 @@ VASTUtil = require '../src/util'
 VASTClient = require '../src/client'
 
 urlfor = (relpath) ->
-    return 'file://' + path.resolve(path.dirname(module.filename), relpath)
+    return 'file://' + path.resolve(path.dirname(module.filename), relpath).replace(/\\/g, '/')
 
 describe 'VASTClient Storage', ->
     wrapperUrl = urlfor('wrapper.xml')

--- a/test/tracker.coffee
+++ b/test/tracker.coffee
@@ -5,7 +5,7 @@ VASTUtil = require('../src/util.coffee')
 VASTTracker = require '../src/tracker'
 
 urlfor = (relpath) ->
-    return 'file://' + path.resolve(path.dirname(module.filename), relpath)
+    return 'file://' + path.resolve(path.dirname(module.filename), relpath).replace(/\\/g, '/')
 
 describe 'VASTTracker', ->
     describe '#constructor', ->

--- a/test/urlhandler.coffee
+++ b/test/urlhandler.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 URLHandler = require '../src/urlhandler'
 
 urlfor = (relpath) ->
-    return 'file://' + path.resolve(path.dirname(module.filename), relpath)
+    return 'file://' + path.resolve(path.dirname(module.filename), relpath).replace(/\\/g, '/')
 
 describe 'URLHandler', ->
     describe '#get', ->


### PR DESCRIPTION
It's impossible to pass tests on Windows because [Parser](https://github.com/dailymotion/vast-client-js/blob/master/src/parser.coffee#L102) doesn't resolve backslashes in relative URLs so you get incorrect absolute path.

Added replacement of backslashes with forward slashes to make possible to pass unit tests on Windows.