### PR TITLE
BUGFIX: syntax errors & node.js compatibility

### DIFF
--- a/src/tracker.coffee
+++ b/src/tracker.coffee
@@ -18,15 +18,15 @@ class VASTTracker extends EventEmitter
             'resume', 'pause', 'rewind', 'skip', 'closeLinear', 'close'
         ]
         # Duplicate the creative's trackingEvents property so we can alter it
-        for eventName, events of creative.trackingEvents
+        for eventName, events of @creative.trackingEvents
             @trackingEvents[eventName] = events.slice(0)
-        if creative instanceof VASTCreativeLinear
-            @setDuration creative.duration
+        if @creative instanceof VASTCreativeLinear
+            @setDuration @creative.duration
 
-            @skipDelay = creative.skipDelay
+            @skipDelay = @creative.skipDelay
             @linear = yes
-            @clickThroughURLTemplate = creative.videoClickThroughURLTemplate
-            @clickTrackingURLTemplates = creative.videoClickTrackingURLTemplates
+            @clickThroughURLTemplate = @creative.videoClickThroughURLTemplate
+            @clickTrackingURLTemplates = @creative.videoClickTrackingURLTemplates
         else
             @skipDelay = -1
             @linear = no

--- a/src/urlhandlers/node.coffee
+++ b/src/urlhandlers/node.coffee
@@ -5,7 +5,7 @@ DOMParser = require('xmldom').DOMParser
 
 class NodeURLHandler
     @get: (url, options, cb) ->
-   
+
         url = uri.parse(url)
         if url.protocol is 'file:'
             fs.readFile url.pathname, 'utf8', (err, data) ->
@@ -15,7 +15,7 @@ class NodeURLHandler
         else
             data = ''
 
-            timeout_wrapper ( req ) ->
+            timeout_wrapper = ( req ) ->
                 return ->
                     req.abort( );
 
@@ -23,7 +23,7 @@ class NodeURLHandler
                 res.on 'data', (chunk) ->
                     data += chunk
                     clearTimeout( timing );
-                    timing = setTimeout( fn, timeout );
+                    timing = setTimeout( fn, options.timeout or 120000 );
                 res.on 'end', ->
                     clearTimeout( timing );
                     xml = new DOMParser().parseFromString(data)
@@ -31,8 +31,8 @@ class NodeURLHandler
             req.on 'error', (err) ->
                 clearTimeout( timing );
                 cb(err)
-            
+
             fn = timeout_wrapper req
-            timing = setTimeout( fn, timeout );
+            timing = setTimeout( fn, options.timeout or 120000 );
 
 module.exports = NodeURLHandler


### PR DESCRIPTION
There are two simple but significant fixes in this PR.  There is not a topic branch for this pull, but the test suite does pass.

1) CoffeeScript syntax error: assumption of constructor parameter names (in this case, Tracker's contructor usage of local variables to access constructor parameter creative).  In CoffeeScript 1.9.x, these names are not the same as the instance variable name given in the constructor definition when there is a reference to a local variable of the same name within the constructor.  Discussion here: https://github.com/jashkenas/coffeescript/issues/3891

2) Node.js: NodeURLHandler had a syntax error in the definition of a local function called "timeout_wrapper".  Additionally, there was no default timeout - which resulted in a timeout of null.  In the browser (using XHR request) a 0 timeout is the default value, and results in reasonable behavior, but a 0 timeout in node means 0ms, and every connection attempt would result in a failed connection ("socket hung up").  A default value of 12s is now used (which is node's normal default).