### PR TITLE
Node.js and vanilla JavaScript Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+dist/*
 node_modules/*
 bower_components/*

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "engines": {
         "node": "0.10.26"
     },
+    "main": "dist/index.js",
     "scripts":
     {
         "test": "mocha --compilers coffee:coffee-script/register --reporter spec test/*.coffee",
-        "bundle": "browserify -s DMVAST -c 'coffee -scb' src/index.coffee -o vast-client.js"
+        "bundle": "browserify -s DMVAST -c 'coffee -scb' src/index.coffee -o vast-client.js",
+        "postinstall": "coffee --compile --output dist/ src/"
     },
     "devDependencies":
     {

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -1,5 +1,5 @@
-VASTParser = require './parser.coffee'
-VASTUtil = require './util.coffee'
+VASTParser = require './parser'
+VASTUtil = require './util'
 
 class VASTClient
     @cappingFreeLunch: 0

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,5 +1,5 @@
 module.exports =
-    client: require './client.coffee'
-    tracker: require './tracker.coffee'
-    parser: require './parser.coffee'
-    util: require './util.coffee'
+    client: require './client'
+    tracker: require './tracker'
+    parser: require './parser'
+    util: require './util'

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -1,11 +1,11 @@
-URLHandler = require './urlhandler.coffee'
-VASTResponse = require './response.coffee'
-VASTAd = require './ad.coffee'
-VASTUtil = require './util.coffee'
-VASTCreativeLinear = require('./creative.coffee').VASTCreativeLinear
-VASTCreativeCompanion = require('./creative.coffee').VASTCreativeCompanion
-VASTMediaFile = require './mediafile.coffee'
-VASTCompanionAd = require './companionad.coffee'
+URLHandler = require './urlhandler'
+VASTResponse = require './response'
+VASTAd = require './ad'
+VASTUtil = require './util'
+VASTCreativeLinear = require('./creative').VASTCreativeLinear
+VASTCreativeCompanion = require('./creative').VASTCreativeCompanion
+VASTMediaFile = require './mediafile'
+VASTCompanionAd = require './companionad'
 EventEmitter = require('events').EventEmitter
 
 class VASTParser

--- a/src/tracker.coffee
+++ b/src/tracker.coffee
@@ -1,6 +1,6 @@
-VASTClient = require('./client.coffee')
-VASTUtil = require('./util.coffee')
-VASTCreativeLinear = require('./creative.coffee').VASTCreativeLinear
+VASTClient = require('./client')
+VASTUtil = require('./util')
+VASTCreativeLinear = require('./creative').VASTCreativeLinear
 EventEmitter = require('events').EventEmitter
 
 class VASTTracker extends EventEmitter

--- a/src/urlhandler.coffee
+++ b/src/urlhandler.coffee
@@ -1,5 +1,5 @@
-xhr = require './urlhandlers/xmlhttprequest.coffee'
-flash = require './urlhandlers/flash.coffee'
+xhr = require './urlhandlers/xmlhttprequest'
+flash = require './urlhandlers/flash'
 
 class URLHandler
     @get: (url, options, cb) ->
@@ -12,7 +12,7 @@ class URLHandler
             return options.urlhandler.get(url, options, cb)
         else if not window?
             # prevents browserify from including this file
-            return require('./urlhandlers/' + 'node.coffee').get(url, options, cb)
+            return require('./urlhandlers/' + 'node').get(url, options, cb)
         else if xhr.supported()
             return xhr.get(url, options, cb)
         else if flash.supported()


### PR DESCRIPTION
Hi,

This PR ads support for using this module in pure nodejs/javascript - intended use case is using inside  browserify.

All tests still pass. Little actual code change, just removing the `.coffee` from all require statements. Coffee -> js compilation is done as an npm `postinstall` hook.

I'd also like to +1 Issue #76 Publish on NPM - would make life a little bit easier.

Thanks. Great library, much appreciated.

Nathan