### PR TITLE
Add ability to pass the VAST response XML document in the options

### DIFF
--- a/src/urlhandler.coffee
+++ b/src/urlhandler.coffee
@@ -3,11 +3,15 @@ flash = require './urlhandlers/flash'
 
 class URLHandler
     @get: (url, options, cb) ->
+        # Allow skip of the options param
         if not cb
             cb = options if typeof options is 'function'
             options = {}
 
-        if options.urlhandler && options.urlhandler.supported()
+        if options.response?
+            # Trick: the VAST response XML document is passed as an option
+            cb(null, options.response)
+        else if options.urlhandler && options.urlhandler.supported()
             # explicitly supply your own URLHandler object
             return options.urlhandler.get(url, options, cb)
         else if not window?

--- a/src/urlhandler.coffee
+++ b/src/urlhandler.coffee
@@ -11,7 +11,7 @@ class URLHandler
         if options.response?
             # Trick: the VAST response XML document is passed as an option
             cb(null, options.response)
-        else if options.urlhandler && options.urlhandler.supported()
+        else if options.urlhandler?.supported()
             # explicitly supply your own URLHandler object
             return options.urlhandler.get(url, options, cb)
         else if not window?

--- a/test/urlhandler.coffee
+++ b/test/urlhandler.coffee
@@ -7,6 +7,13 @@ urlfor = (relpath) ->
 
 describe 'URLHandler', ->
     describe '#get', ->
+        it 'should return options.response when it\'s provided', (done) =>
+            URLHandler.get urlfor('sample.xml'), {response: 'response'}, (err, xml) ->
+                should.not.exist err
+                should.exists xml
+                xml.should.equal 'response'
+                done()
+
         it 'should return a VAST XML DOM object', (done) =>
             URLHandler.get urlfor('sample.xml'), (err, xml) ->
                 should.not.exist err


### PR DESCRIPTION
In some cases, you may have the VAST response in hand, and you don't
want the VAST client to fetch it from an URL but still want to let it
resolve wrappers if any. This PR let you passe the XML VAST response
as the `response` field of the `options` parameter. In this case, the
`url` parameter is ignored and the provided response is returned to
the parser.

@dharFr: please review