### PR TITLE
Moved xmldom to dependencies from devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "devDependencies":
     {
         "mocha": "1.18.2",
-        "should": "3.2.0",
-        "xmldom": "0.1.19"
+        "should": "3.2.0"
     },
     "dependencies":
     {
         "coffee-script": "~1.7.1",
-        "browserify": "4.2.1"
+        "browserify": "4.2.1",
+        "xmldom": "0.1.19"
     }
 }


### PR DESCRIPTION
Otherwise vast-client will fail when used with node, since it will
not find module xmldom.
devDependencies do no get installed when installing the package.