### PR TITLE
work around for chrome bug

### DIFF
--- a/src/urlhandlers/xmlhttprequest.coffee
+++ b/src/urlhandlers/xmlhttprequest.coffee
@@ -8,7 +8,9 @@ class XHRURLHandler
         return !!@xhr()
 
     @get: (url, options, cb) ->
-       
+        if window.location.protocol == 'https:' && url.indexOf('http://') == 0
+            return cb(new Error('Cannot go from HTTPS to HTTP.'))
+
         try
             xhr = @xhr()
             xhr.open('GET', url)

--- a/vast-client.js
+++ b/vast-client.js
@@ -1402,7 +1402,7 @@ XHRURLHandler = (function() {
   XHRURLHandler.get = function(url, options, cb) {
     var xhr;
     if (window.location.protocol === 'https:' && url.indexOf('http://') === 0) {
-      return cb();
+      return cb(new Error('Cannot go from HTTPS to HTTP.'));
     }
     try {
       xhr = this.xhr();

--- a/vast-client.js
+++ b/vast-client.js
@@ -1401,6 +1401,9 @@ XHRURLHandler = (function() {
 
   XHRURLHandler.get = function(url, options, cb) {
     var xhr;
+    if (window.location.protocol === 'https:' && url.indexOf('http://') === 0) {
+      return cb();
+    }
     try {
       xhr = this.xhr();
       xhr.open('GET', url);


### PR DESCRIPTION
If you try to load vast tags via HTTP from HTTPS, an uncatchable error happens and the stack just stalls out. This does a check first so you don't have to rely on a timer.

https://code.google.com/p/chromium/issues/detail?can=2&start=0&num=100&q=&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Cr%20Status%20Owner%20Summary%20OS%20Modified&groupby=&sort=&id=389326