### PR TITLE
Override mime type to handle valid VAST xml with wrong mime type.

### DIFF
--- a/src/urlhandlers/xmlhttprequest.coffee
+++ b/src/urlhandlers/xmlhttprequest.coffee
@@ -16,6 +16,7 @@ class XHRURLHandler
             xhr.open('GET', url)
             xhr.timeout = options.timeout or 0
             xhr.withCredentials = options.withCredentials or false
+            xhr.overrideMimeType('text/xml');
             xhr.send()
             xhr.onreadystatechange = ->
                 if xhr.readyState == 4


### PR DESCRIPTION
An adserver send us a valid vast with a wrong mime type. To handle this case we decided to override the mime type.