### PR TITLE
Added support for CompanionClickTracking property to VAST parser

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -386,6 +386,7 @@ class VASTParser
                         companionAd.trackingEvents[eventName] ?= []
                         companionAd.trackingEvents[eventName].push trackingURLTemplate
             companionAd.companionClickThroughURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickThrough"))
+            companionAd.companionClickTrackingURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickTracking"))
             creative.variations.push companionAd
 
         return creative

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -148,6 +148,9 @@ describe 'VASTParser', ->
                     it 'should have 1 companion clickthrough url', =>
                         companion.companionClickThroughURLTemplate.should.equal  'http://example.com/companion-clickthrough'
 
+                    it 'should have 1 companion clicktracking url', =>
+                        companion.companionClickTrackingURLTemplate.should.equal  'http://example.com/companion-clicktracking'
+
                 describe 'as IFrameResource', ->
                   before (done) =>
                       companion = companions.variations[1]

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -41,6 +41,7 @@
                 <Tracking event="creativeView"><![CDATA[http://example.com/creativeview]]></Tracking>
               </TrackingEvents>
               <CompanionClickThrough><![CDATA[http://example.com/companion-clickthrough]]></CompanionClickThrough>
+              <CompanionClickTracking><![CDATA[http://example.com/companion-clicktracking]]></CompanionClickTracking>
             </Companion>
             <Companion width="300" height="60">
               <IFrameResource>


### PR DESCRIPTION
When parsing companion ads, the VAST parser currently does not
load the optional CompanionClickTracking parameter. The value of
this parameter is required when implementing click tracking, so it
is worth including it in the parser's output. I added a line to read
the value of this parameter and return it in the companion ad object