### PR TITLE
Added support for multiple companion click tracking properties

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -369,6 +369,7 @@ class VASTParser
             companionAd.id = companionResource.getAttribute("id") or null
             companionAd.width = companionResource.getAttribute("width")
             companionAd.height = companionResource.getAttribute("height")
+            companionAd.companionClickTrackingURLTemplates = []
             for htmlElement in @childsByName(companionResource, "HTMLResource")
                 companionAd.type = htmlElement.getAttribute("creativeType") or 'text/html'
                 companionAd.htmlResource = @parseNodeText(htmlElement)
@@ -385,8 +386,10 @@ class VASTParser
                     if eventName? and trackingURLTemplate?
                         companionAd.trackingEvents[eventName] ?= []
                         companionAd.trackingEvents[eventName].push trackingURLTemplate
+            for clickTrackingElement in @childsByName(companionResource, "CompanionClickTracking")
+              companionAd.companionClickTrackingURLTemplates.push @parseNodeText(clickTrackingElement)
             companionAd.companionClickThroughURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickThrough"))
-            companionAd.companionClickTrackingURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickTracking"))
+
             creative.variations.push companionAd
 
         return creative

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -389,7 +389,7 @@ class VASTParser
             for clickTrackingElement in @childsByName(companionResource, "CompanionClickTracking")
               companionAd.companionClickTrackingURLTemplates.push @parseNodeText(clickTrackingElement)
             companionAd.companionClickThroughURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickThrough"))
-
+            companionAd.companionClickTrackingURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickTracking"))
             creative.variations.push companionAd
 
         return creative

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -148,8 +148,9 @@ describe 'VASTParser', ->
                     it 'should have 1 companion clickthrough url', =>
                         companion.companionClickThroughURLTemplate.should.equal  'http://example.com/companion-clickthrough'
 
-                    it 'should have 1 companion clicktracking url', =>
-                        companion.companionClickTrackingURLTemplate.should.equal  'http://example.com/companion-clicktracking'
+                    it 'should have 2 companion clicktracking urls', =>
+                        companion.companionClickTrackingURLTemplates[0].should.equal  'http://example.com/companion-clicktracking-first'
+                        companion.companionClickTrackingURLTemplates[1].should.equal  'http://example.com/companion-clicktracking-second'
 
                 describe 'as IFrameResource', ->
                   before (done) =>

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -148,6 +148,9 @@ describe 'VASTParser', ->
                     it 'should have 1 companion clickthrough url', =>
                         companion.companionClickThroughURLTemplate.should.equal  'http://example.com/companion-clickthrough'
 
+                    it 'should store the first companion clicktracking url', =>
+                        companion.companionClickTrackingURLTemplate.should.equal 'http://example.com/companion-clicktracking-first'
+
                     it 'should have 2 companion clicktracking urls', =>
                         companion.companionClickTrackingURLTemplates[0].should.equal  'http://example.com/companion-clicktracking-first'
                         companion.companionClickTrackingURLTemplates[1].should.equal  'http://example.com/companion-clicktracking-second'

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -41,7 +41,8 @@
                 <Tracking event="creativeView"><![CDATA[http://example.com/creativeview]]></Tracking>
               </TrackingEvents>
               <CompanionClickThrough><![CDATA[http://example.com/companion-clickthrough]]></CompanionClickThrough>
-              <CompanionClickTracking><![CDATA[http://example.com/companion-clicktracking]]></CompanionClickTracking>
+              <CompanionClickTracking><![CDATA[http://example.com/companion-clicktracking-first]]></CompanionClickTracking>
+              <CompanionClickTracking><![CDATA[http://example.com/companion-clicktracking-second]]></CompanionClickTracking>
             </Companion>
             <Companion width="300" height="60">
               <IFrameResource>


### PR DESCRIPTION
I have to apologise for an oversight on my part. Earlier I [submitted a PR](https://github.com/dailymotion/vast-client-js/pull/108) which added support for the CompanionClickTracking property which appears in VAST companion ads. The VAST spec doesn't make it entirely clear, but companion ads can have multiple CompanionClickTracking elements, indicating that all of those URLs should be pinged if the companion ad is clicked.

I tried to find a better source of information to confirm the expected behaviour but the most I could discover is that several VAST tags in the wild appear to be using multiple CompanionClickTracking properties. I therefore modified my original change to the parser so that it returns an array called companionClickTrackingURLTemplates instead of a string called companionClickTrackingURLTemplate.

Sorry for any inconvenience this caused :( I'm finding it quite difficult to get reliable information on the expected format of VAST tags.
