### PR TITLE
Fix IE9 - setAttribute

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -164,7 +164,9 @@ class VASTParser
 
     @parseAdElement: (adElement) ->
         for adTypeElement in adElement.childNodes
-            adTypeElement.id = adElement.getAttribute("id")
+            continue unless adTypeElement.nodeName in ["Wrapper", "InLine"]
+
+            adTypeElement.setAttribute "id", adElement.getAttribute("id")
             if adTypeElement.nodeName is "Wrapper"
                 return @parseWrapperElement adTypeElement
             else if adTypeElement.nodeName is "InLine"


### PR DESCRIPTION
Use `setAttibute()` for setting an attribute on an element. I've also added a test to discard `textNode` elements