### PR TITLE
First onreadystatechange then send

### DIFF
--- a/src/urlhandlers/xmlhttprequest.coffee
+++ b/src/urlhandlers/xmlhttprequest.coffee
@@ -17,10 +17,10 @@ class XHRURLHandler
             xhr.timeout = options.timeout or 0
             xhr.withCredentials = options.withCredentials or false
             xhr.overrideMimeType('text/xml');
-            xhr.send()
             xhr.onreadystatechange = ->
                 if xhr.readyState == 4
                     cb(null, xhr.responseXML)
+            xhr.send()
         catch
             cb()
 


### PR DESCRIPTION
If nested URL inside `VASTAdTagURI` tag is `http://`, `xhr.send()` will throw an error and a `try` block will end without calling callback.