### PR TITLE
checks for existence of XMLHttpRequest.overrideMimeType

### DIFF
--- a/src/urlhandlers/xmlhttprequest.coffee
+++ b/src/urlhandlers/xmlhttprequest.coffee
@@ -16,7 +16,7 @@ class XHRURLHandler
             xhr.open('GET', url)
             xhr.timeout = options.timeout or 0
             xhr.withCredentials = options.withCredentials or false
-            xhr.overrideMimeType('text/xml');
+            xhr.overrideMimeType && xhr.overrideMimeType('text/xml');
             xhr.onreadystatechange = ->
                 if xhr.readyState == 4
                     cb(null, xhr.responseXML)


### PR DESCRIPTION
This is a fix to the issue described [here](https://github.com/dailymotion/vast-client-js/issues/117).

