### PR TITLE
Ping <Error> when no ads found

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -77,12 +77,12 @@ class VASTParser
 
             complete = (errorAlreadyRaised = false) =>
                 return unless response
-                hasAdWithCreative = false
+                noCreatives = true
                 for ad in response.ads
                     return if ad.nextWrapperURL?
                     if ad.creatives.length > 0
-                        hasAdWithCreative = true
-                if not hasAdWithCreative
+                        noCreatives = false
+                if noCreatives
                     # No Ad Response
                     # The VAST <Error> element is optional but if included, the video player must send a request to the URI
                     # provided when the VAST response returns an empty InLine response after a chain of one or more wrapper ads.

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -77,14 +77,18 @@ class VASTParser
 
             complete = (errorAlreadyRaised = false) =>
                 return unless response
+                hasAdWithCreative = false
                 for ad in response.ads
                     return if ad.nextWrapperURL?
-                if response.ads.length == 0
+                    if ad.creatives.length > 0
+                        hasAdWithCreative = true
+                if not hasAdWithCreative
                     # No Ad Response
                     # The VAST <Error> element is optional but if included, the video player must send a request to the URI
                     # provided when the VAST response returns an empty InLine response after a chain of one or more wrapper ads.
                     # If an [ERRORCODE] macro is included, the video player should substitute with error code 303.
                     @track(response.errorURLTemplates, ERRORCODE: 303) unless errorAlreadyRaised
+                if response.ads.length == 0
                     response = null
                 cb(null, response)
 

--- a/test/empty-no-creative.xml
+++ b/test/empty-no-creative.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST version="3.0">
+    <Ad>
+        <InLine>
+        </InLine>
+    </Ad>
+</VAST>

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -216,6 +216,14 @@ describe 'VASTParser', ->
                 errorCode.ERRORCODE.should.eql 303
                 done()
 
+        # VAST response with Ad but no Creative
+        it 'emits a VAST-error on response with no Creative', (done) ->
+            VASTParser.on 'VAST-error', errorCallback
+            VASTParser.parse urlfor('empty-no-creative.xml'), =>
+                errorCallbackCalled.should.equal 1
+                errorCode.ERRORCODE.should.eql 303
+                done()
+
         #No ads VAST response after more than one wrapper
         # Two events should be emits :
         # - 1 for the empty vast file


### PR DESCRIPTION
Hi,

This PR is about pinging `<Error>` URLs when no ads are found in the given VAST.

Currently, we do that by looking for `<Ad>` nodes in the response ([here](https://github.com/dailymotion/vast-client-js/blob/2a64c454b618a2f9eb4e5c79b9e58ba62a9ba682/src/parser.coffee#L78-L89)).
Instead, we could look for `<Ad>` nodes with a `<Creative>`.

With this method, the `<Error>` URLs would still be pinged in case of a VAST with an empty `<Ad>`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<VAST version="3.0">
    <Ad>
        <InLine>
        </InLine>
    </Ad>
    <Error>
        [...]
    </Error>
</VAST>
```