### PR TITLE
Time between 2 VAST calls can only be null or positive

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -35,7 +35,12 @@ class VASTClient
             cb(null, new Error("VAST call canceled – FreeLunch capping not reached yet #{@totalCalls}/#{@cappingFreeLunch}"))
             return
 
-        if now - @lastSuccessfullAd < @cappingMinimumTimeInterval
+        timeSinceLastCall = now - @lastSuccessfullAd
+        # Check timeSinceLastCall to be a positive number. If not, this mean the
+        # previous was made in the future. We reset lastSuccessfullAd value
+        if timeSinceLastCall < 0
+            @lastSuccessfullAd = 0
+        else if timeSinceLastCall < @cappingMinimumTimeInterval
             cb(null, new Error("VAST call canceled – (#{@cappingMinimumTimeInterval})ms minimum interval reached"))
             return
 
@@ -63,6 +68,7 @@ class VASTClient
             return
 
         # Init values if not already set
+        VASTClient.lastSuccessfullAd ?= 0
         VASTClient.totalCalls ?= 0
         VASTClient.totalCallsTimeout ?= 0
         return


### PR DESCRIPTION
Some users may encounter a bug where no VAST call are done. This is due to the minimum interval capping being enabled because the difference between the current time (`now`) and the last time we made a VAST call (`@lastSuccessfullAd`) is negative.

We solve this by checking that `@lastSuccessfullAd` cannot be greater than `now`. If so, we reset `@lastSuccessfullAd`.