### PR TITLE
only call error callback after request complete and status is not 200

### DIFF
--- a/src/urlhandlers/xmlhttprequest.coffee
+++ b/src/urlhandlers/xmlhttprequest.coffee
@@ -19,9 +19,10 @@ class XHRURLHandler
             xhr.overrideMimeType && xhr.overrideMimeType('text/xml');
             xhr.onreadystatechange = ->
                 if xhr.readyState == 4
-                    cb(null, xhr.responseXML)
-                else
-                    cb(new Error("XHRURLHandler: #{xhr.statusText}"))
+                    if xhr.status == 200
+                        cb(null, xhr.responseXML)
+                    else
+                        cb(new Error("XHRURLHandler: #{xhr.statusText}"))
             xhr.send()
         catch
             cb(new Error('XHRURLHandler: Unexpected error'))


### PR DESCRIPTION
#123

Error callback was called when readyStatus was 1 (OPENED), 2 (HEADERS_RECEIVED), or 3(LOADING), which caused the response to become null when it shouldn't.