### PR TITLE
Retrieve all Ad/Inline elements values and attributes

### DIFF
--- a/src/ad.coffee
+++ b/src/ad.coffee
@@ -1,6 +1,13 @@
 class VASTAd
     constructor: ->
         @id = null
+        @sequence = null
+        @system = null
+        @title = null
+        @description = null
+        @advertiser = null
+        @pricing = null
+        @survey = null
         @errorURLTemplates = []
         @impressionURLTemplates = []
         @creatives = []

--- a/src/creative.coffee
+++ b/src/creative.coffee
@@ -13,6 +13,7 @@ class VASTCreativeLinear extends VASTCreative
         @videoClickTrackingURLTemplates = []
         @videoCustomClickURLTemplates = []
         @adParameters = null
+        @icons = []
 
 class VASTCreativeNonLinear extends VASTCreative
     constructor: ->

--- a/src/icon.coffee
+++ b/src/icon.coffee
@@ -1,0 +1,19 @@
+class VASTIcon
+    constructor: ->
+        @program = null
+        @height = 0
+        @width = 0
+        @xPosition = 0
+        @yPosition = 0
+        @apiFramework = null
+        @offset = null
+        @duration = 0
+        @type = null
+        @staticResource = null
+        @htmlResource = null
+        @iframeResource = null
+        @iconClickThroughURLTemplate = null
+        @iconClickTrackingURLTemplates = []
+        @iconViewTrackingURLTemplate = null
+
+module.exports = VASTIcon

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -171,6 +171,8 @@ class VASTParser
             continue unless adTypeElement.nodeName in ["Wrapper", "InLine"]
 
             adTypeElement.setAttribute "id", adElement.getAttribute("id")
+            adTypeElement.setAttribute "sequence", adElement.getAttribute("sequence")
+
             if adTypeElement.nodeName is "Wrapper"
                 return @parseWrapperElement adTypeElement
             else if adTypeElement.nodeName is "InLine"
@@ -202,7 +204,8 @@ class VASTParser
 
     @parseInLineElement: (inLineElement) ->
         ad = new VASTAd()
-        ad.id = inLineElement.id
+        ad.id = inLineElement.getAttribute("id") || null
+        ad.sequence = inLineElement.getAttribute("sequence") || null
 
         for node in inLineElement.childNodes
             switch node.nodeName
@@ -231,6 +234,28 @@ class VASTParser
                 when "Extensions"
                     @parseExtension(ad.extensions, @childsByName(node, "Extension"))
 
+                when "AdSystem"
+                    ad.system =
+                        value : @parseNodeText node
+                        version : node.getAttribute("version") || null
+
+                when "AdTitle"
+                    ad.title = @parseNodeText node
+
+                when "Description"
+                    ad.description = @parseNodeText node
+
+                when "Advertiser"
+                    ad.advertiser = @parseNodeText node
+
+                when "Pricing"
+                    ad.pricing =
+                        value    : @parseNodeText node
+                        model    : node.getAttribute("model") || null
+                        currency : node.getAttribute("currency") || null
+
+                when "Survey"
+                    ad.survey = @parseNodeText node
 
         return ad
 

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -8,6 +8,7 @@ VASTCreativeLinear = require('./creative').VASTCreativeLinear
 VASTCreativeCompanion = require('./creative').VASTCreativeCompanion
 VASTCreativeNonLinear = require('./creative').VASTCreativeNonLinear
 VASTMediaFile = require './mediafile'
+VASTIcon = require './icon'
 VASTCompanionAd = require './companionad'
 VASTNonLinear = require './nonlinear'
 EventEmitter = require('events').EventEmitter
@@ -354,6 +355,41 @@ class VASTParser
 
                 creative.mediaFiles.push mediaFile
 
+        iconsElement = @childByName(creativeElement, "Icons")
+        if iconsElement?
+            for iconElement in @childsByName(iconsElement, "Icon")
+                icon = new VASTIcon()
+                icon.program = iconElement.getAttribute("program")
+                icon.height = parseInt iconElement.getAttribute("height") or 0
+                icon.width = parseInt iconElement.getAttribute("width") or 0
+                icon.xPosition = @parseXPosition iconElement.getAttribute("xPosition")
+                icon.yPosition = @parseYPosition iconElement.getAttribute("yPosition")
+                icon.apiFramework = iconElement.getAttribute("apiFramework")
+                icon.offset = @parseDuration iconElement.getAttribute("offset")
+                icon.duration = @parseDuration iconElement.getAttribute("duration")
+
+                for htmlElement in @childsByName(iconElement, "HTMLResource")
+                    icon.type = htmlElement.getAttribute("creativeType") or 'text/html'
+                    icon.htmlResource = @parseNodeText(htmlElement)
+
+                for iframeElement in @childsByName(iconElement, "IFrameResource")
+                    icon.type = iframeElement.getAttribute("creativeType") or 0
+                    icon.iframeResource = @parseNodeText(iframeElement)
+
+                for staticElement in @childsByName(iconElement, "StaticResource")
+                    icon.type = staticElement.getAttribute("creativeType") or 0
+                    icon.staticResource = @parseNodeText(staticElement)
+
+                iconClicksElement = @childByName(iconElement, "IconClicks")
+                if iconClicksElement?
+                    icon.iconClickThroughURLTemplate = @parseNodeText(@childByName(iconClicksElement, "IconClickThrough"))
+                    for iconClickTrackingElement in @childsByName(iconClicksElement, "IconClickTracking")
+                        icon.iconClickTrackingURLTemplates.push @parseNodeText(iconClickTrackingElement)
+
+                icon.iconViewTrackingURLTemplate = @parseNodeText(@childByName(iconElement, "IconViewTracking"))
+
+                creative.icons.push icon
+
         return creative
 
     @parseNonLinear: (creativeElement) ->
@@ -440,6 +476,18 @@ class VASTParser
         if isNaN hours or isNaN minutes or isNaN seconds or minutes > 60 * 60 or seconds > 60
             return -1
         return hours + minutes + seconds
+
+    @parseXPosition: (xPosition) ->
+        if xPosition in ["left", "right"]
+            return xPosition
+
+        return parseInt xPosition or 0
+
+    @parseYPosition: (yPosition) ->
+        if yPosition in ["top", "bottom"]
+            return yPosition
+
+        return parseInt yPosition or 0
 
     # Parsing node text for legacy support
     @parseNodeText: (node) ->

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -39,6 +39,36 @@ describe 'VASTParser', ->
         it 'should have merged top level error URLs', =>
             @response.errorURLTemplates.should.eql ["http://example.com/wrapper-error", "http://example.com/error"]
 
+        it 'should have retrieved Ad id attribute', =>
+            @response.ads[0].id.should.eql "41993e28-6f21-4e6b-bbd4-b7de053b0951"
+
+        it 'should have retrieved Ad sequence attribute', =>
+            @response.ads[0].sequence.should.eql "0"
+
+        it 'should have retrieved AdSystem value', =>
+            @response.ads[0].system.value.should.eql "AdServer"
+
+        it 'should have retrieved AdSystem version attribute', =>
+            @response.ads[0].system.version.should.eql "2.0"
+
+        it 'should have retrieved AdTitle value', =>
+            @response.ads[0].title.should.eql "Ad title"
+
+        it 'should have retrieved Advertiser value', =>
+            @response.ads[0].advertiser.should.eql "Advertiser name"
+
+        it 'should have retrieved Description value', =>
+            @response.ads[0].description.should.eql "Description text"
+
+        it 'should have retrieved Pricing value', =>
+            @response.ads[0].pricing.value.should.eql "1.09"
+
+        it 'should have retrieved Pricing model attribute', =>
+            @response.ads[0].pricing.model.should.eql "CPM"
+
+        it 'should have retrieved Pricing currency attribute', =>
+            @response.ads[0].pricing.currency.should.eql "USD"
+
         it 'should have merged wrapped ad error URLs', =>
             @response.ads[0].errorURLTemplates.should.eql ["http://example.com/wrapper-error", "http://example.com/error"]
 

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -141,6 +141,22 @@ describe 'VASTParser', ->
             it 'should have 2 urls for progress-60% event VAST 3.0', =>
                 linear.trackingEvents['progress-60%'].should.eql ['http://example.com/progress-60%', 'http://example.com/wrapper-progress-60%']
 
+            it 'should have parsed icons element', =>
+                icon = linear.icons[0]
+                icon.program.should.equal "ad1"
+                icon.height.should.equal 20
+                icon.width.should.equal 60
+                icon.xPosition.should.equal "left"
+                icon.yPosition.should.equal "bottom"
+                icon.apiFramework.should.equal "VPAID"
+                icon.offset.should.equal 15
+                icon.duration.should.equal 90
+                icon.type.should.equal "image/gif"
+                icon.staticResource.should.equal "http://example.com/icon.gif"
+                icon.iconClickThroughURLTemplate.should.equal "http://example.com/clickthrough"
+                icon.iconClickTrackingURLTemplates.should.eql ["http://example.com/clicktracking1", "http://example.com/clicktracking2"]
+                icon.iconViewTrackingURLTemplate.should.equal "http://example.com/viewtracking"
+
         #Companions
         describe '#Companions', ->
             companions = null

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -35,6 +35,17 @@
             <MediaFiles>
               <MediaFile delivery="progressive" type="video/mp4" bitrate="849" width="512" height="288" scalable="true"><![CDATA[http://example.com/asset.mp4]]></MediaFile>
             </MediaFiles>
+            <Icons>
+              <Icon program="ad1" width="60" height="20" xPosition="left" yPosition="bottom" duration="00:01:30.000" offset="00:00:15.000" apiFramework="VPAID">
+                <StaticResource creativeType="image/gif"><![CDATA[http://example.com/icon.gif]]></StaticResource>
+                <IconViewTracking><![CDATA[http://example.com/viewtracking]]></IconViewTracking>
+                <IconClicks>
+                  <IconClickThrough><![CDATA[http://example.com/clickthrough]]></IconClickThrough>
+                  <IconClickTracking><![CDATA[http://example.com/clicktracking1]]></IconClickTracking>
+                  <IconClickTracking><![CDATA[http://example.com/clicktracking2]]></IconClickTracking>
+                </IconClicks>
+              </Icon>
+            </Icons>
           </Linear>
         </Creative>
         <Creative>

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <VAST version="2.0">
   <Error><![CDATA[http://example.com/error]]></Error>
-  <Ad id="41993e28-6f21-4e6b-bbd4-b7de053b0951">
+  <Ad id="41993e28-6f21-4e6b-bbd4-b7de053b0951" sequence="0">
     <InLine>
-      <AdSystem>AdServer</AdSystem>
-      <AdTitle>Title</AdTitle>
+      <AdSystem version="2.0" ><![CDATA[AdServer]]></AdSystem>
+      <AdTitle><![CDATA[Ad title]]></AdTitle>
+      <Advertiser><![CDATA[Advertiser name]]></Advertiser>
+      <Description><![CDATA[Description text]]></Description>
+      <Pricing model="CPM" currency="USD" ><![CDATA[1.09]]></Pricing>
+      <Survey><![CDATA[http://example.com/survey]]></Survey>
       <Error><![CDATA[http://example.com/error]]></Error>
       <Impression><![CDATA[http://example.com/impression1]]></Impression>
       <Impression><![CDATA[http://example.com/impression2]]></Impression>


### PR DESCRIPTION
Update the VAST Parser so we can retrieve:
- [x] All `<Inline>` element attributes/nodes
- [x] `<Icons>` element