### PR TITLE
Fix attributes with 'null' value

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -171,8 +171,8 @@ class VASTParser
         for adTypeElement in adElement.childNodes
             continue unless adTypeElement.nodeName in ["Wrapper", "InLine"]
 
-            adTypeElement.setAttribute "id", adElement.getAttribute("id")
-            adTypeElement.setAttribute "sequence", adElement.getAttribute("sequence")
+            @copyNodeAttribute "id", adElement, adTypeElement
+            @copyNodeAttribute "sequence", adElement, adTypeElement
 
             if adTypeElement.nodeName is "Wrapper"
                 return @parseWrapperElement adTypeElement
@@ -492,5 +492,10 @@ class VASTParser
     # Parsing node text for legacy support
     @parseNodeText: (node) ->
         return node and (node.textContent or node.text or '').trim()
+
+    @copyNodeAttribute: (attributeName, nodeSource, nodeDestination) ->
+        attributeValue = nodeSource.getAttribute attributeName
+        if attributeValue
+            nodeDestination.setAttribute attributeName, attributeValue
 
 module.exports = VASTParser

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -30,8 +30,8 @@ describe 'VASTParser', ->
             @templateFilterCalls.should.have.length 2
             @templateFilterCalls.should.eql [urlfor('wrapper.xml'), urlfor('sample.xml')]
 
-        it 'should have found 1 ad', =>
-            @response.ads.should.have.length 1
+        it 'should have found 2 ads', =>
+            @response.ads.should.have.length 2
 
         it 'should have returned a VAST response object', =>
             @response.should.be.an.instanceOf(VASTResponse)
@@ -39,62 +39,77 @@ describe 'VASTParser', ->
         it 'should have merged top level error URLs', =>
             @response.errorURLTemplates.should.eql ["http://example.com/wrapper-error", "http://example.com/error"]
 
-        it 'should have retrieved Ad id attribute', =>
-            @response.ads[0].id.should.eql "41993e28-6f21-4e6b-bbd4-b7de053b0951"
+        describe '#For the 1st ad (Wrapped)', ->
 
-        it 'should have retrieved Ad sequence attribute', =>
-            @response.ads[0].sequence.should.eql "0"
+            it 'should have retrieved Ad attributes', =>
+                _response.ads[0].id.should.eql "ad_id_0001"
+                _response.ads[0].sequence.should.eql "1"
 
-        it 'should have retrieved AdSystem value', =>
-            @response.ads[0].system.value.should.eql "AdServer"
+            it 'should have retrieved Ad sub-elements values', =>
+                _response.ads[0].system.value.should.eql "AdServer"
+                _response.ads[0].system.version.should.eql "2.0"
+                _response.ads[0].title.should.eql "Ad title"
+                _response.ads[0].advertiser.should.eql "Advertiser name"
+                _response.ads[0].description.should.eql "Description text"
+                _response.ads[0].pricing.value.should.eql "1.09"
+                _response.ads[0].pricing.model.should.eql "CPM"
+                _response.ads[0].pricing.currency.should.eql "USD"
+                _response.ads[0].survey.should.eql "http://example.com/survey"
 
-        it 'should have retrieved AdSystem version attribute', =>
-            @response.ads[0].system.version.should.eql "2.0"
+            it 'should have merged wrapped ad error URLs', =>
+                _response.ads[0].errorURLTemplates.should.eql ["http://example.com/wrapper-error", "http://example.com/error"]
 
-        it 'should have retrieved AdTitle value', =>
-            @response.ads[0].title.should.eql "Ad title"
+            it 'should have merged impression URLs', =>
+                _response.ads[0].impressionURLTemplates.should.eql ["http://example.com/wrapper-impression", "http://127.0.0.1:8080/second/wrapper_impression", "http://example.com/impression1", "http://example.com/impression2", "http://example.com/impression3"]
 
-        it 'should have retrieved Advertiser value', =>
-            @response.ads[0].advertiser.should.eql "Advertiser name"
+            it 'should have two creatives', =>
+                _response.ads[0].creatives.should.have.length 2
 
-        it 'should have retrieved Description value', =>
-            @response.ads[0].description.should.eql "Description text"
+            it 'should have two extentions', =>
+                _response.ads[0].extensions.should.have.length 2
 
-        it 'should have retrieved Pricing value', =>
-            @response.ads[0].pricing.value.should.eql "1.09"
+            it 'validate first extension', =>
+                _response.ads[0].extensions[0].attributes['type'].should.eql "Pricing"
+                _response.ads[0].extensions[0].children.should.have.length 1
+                _response.ads[0].extensions[0].children[0].name.should.eql "Price"
+                _response.ads[0].extensions[0].children[0].value.should.eql "0"
+                _response.ads[0].extensions[0].children[0].attributes['model'].should.eql "CPM"
+                _response.ads[0].extensions[0].children[0].attributes['currency'].should.eql "USD"
+                _response.ads[0].extensions[0].children[0].attributes['source'].should.eql "someone"
 
-        it 'should have retrieved Pricing model attribute', =>
-            @response.ads[0].pricing.model.should.eql "CPM"
+            it 'validate second extension', =>
+                _response.ads[0].extensions[1].attributes['type'].should.eql "Count"
+                _response.ads[0].extensions[1].children.should.have.length 1
+                _response.ads[0].extensions[1].children[0].name.should.eql "total_available"
+                _response.ads[0].extensions[1].children[0].value.should.eql "4"
 
-        it 'should have retrieved Pricing currency attribute', =>
-            @response.ads[0].pricing.currency.should.eql "USD"
+        describe '#For the 2nd ad (Non wrapped)', ->
 
-        it 'should have merged wrapped ad error URLs', =>
-            @response.ads[0].errorURLTemplates.should.eql ["http://example.com/wrapper-error", "http://example.com/error"]
+            it 'should have retrieved Ad attributes', =>
+                _response.ads[1].id.should.eql "ad_id_0002"
+                should.equal _response.ads[1].sequence, null
 
-        it 'should have merged impression URLs', =>
-            @response.ads[0].impressionURLTemplates.should.eql ["http://example.com/wrapper-impression", "http://127.0.0.1:8080/second/wrapper_impression", "http://example.com/impression1", "http://example.com/impression2", "http://example.com/impression3"]
+            it 'should have retrieved Ad sub-elements values', =>
+                _response.ads[1].system.value.should.eql "AdServer2"
+                _response.ads[1].system.version.should.eql "2.1"
+                _response.ads[1].title.should.eql "Ad title 2"
+                should.equal _response.ads[1].advertiser, null
+                should.equal _response.ads[1].description, null
+                should.equal _response.ads[1].pricing, null
+                should.equal _response.ads[1].survey, null
 
-        it 'should have two creatives', =>
-            @response.ads[0].creatives.should.have.length 2
+            it 'should have 0 error URL', =>
+                _response.ads[1].errorURLTemplates.should.eql []
 
-        it 'should have two extentions', =>
-            @response.ads[0].extensions.should.have.length 2
+            it 'should have 1 impression URL', =>
+                _response.ads[1].impressionURLTemplates.should.eql ["http://example.com/impression1"]
 
-        it 'validate first extension', =>
-            @response.ads[0].extensions[0].attributes['type'].should.eql "Pricing"
-            @response.ads[0].extensions[0].children.should.have.length 1
-            @response.ads[0].extensions[0].children[0].name.should.eql "Price"
-            @response.ads[0].extensions[0].children[0].value.should.eql "0"
-            @response.ads[0].extensions[0].children[0].attributes['model'].should.eql "CPM"
-            @response.ads[0].extensions[0].children[0].attributes['currency'].should.eql "USD"
-            @response.ads[0].extensions[0].children[0].attributes['source'].should.eql "someone"
+            it 'should have 1 creative', =>
+                _response.ads[1].creatives.should.have.length 1
 
-        it 'validate second extension', =>
-            @response.ads[0].extensions[1].attributes['type'].should.eql "Count"
-            @response.ads[0].extensions[1].children.should.have.length 1
-            @response.ads[0].extensions[1].children[0].name.should.eql "total_available"
-            @response.ads[0].extensions[1].children[0].value.should.eql "4"
+            it 'should have 0 extentions', =>
+                _response.ads[1].extensions.should.eql []
+
 
         #Linear
         describe '#Linear', ->

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -144,6 +144,9 @@ describe 'VASTParser', ->
             it 'should have 2 urls for complete event', =>
                 linear.trackingEvents['complete'].should.eql ['http://example.com/complete', 'http://example.com/wrapper-complete']
 
+            it 'should have 1 url for clickthrough', =>
+                linear.videoClickThroughURLTemplate.should.eql 'http://example.com/clickthrough'
+
             it 'should have 2 urls for clicktracking', =>
                 linear.videoClickTrackingURLTemplates.should.eql ['http://example.com/clicktracking', 'http://example.com/wrapper-clicktracking']
 

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <VAST version="2.0">
   <Error><![CDATA[http://example.com/error]]></Error>
-  <Ad id="41993e28-6f21-4e6b-bbd4-b7de053b0951" sequence="0">
+  <Ad id="ad_id_0001" sequence="1">
     <InLine>
       <AdSystem version="2.0" ><![CDATA[AdServer]]></AdSystem>
       <AdTitle><![CDATA[Ad title]]></AdTitle>

--- a/test/wrapper.xml
+++ b/test/wrapper.xml
@@ -42,4 +42,21 @@
       </Creatives>
     </Wrapper>
   </Ad>
+  <Ad id="ad_id_0002">
+    <InLine>
+      <AdSystem version="2.1" ><![CDATA[AdServer2]]></AdSystem>
+      <AdTitle><![CDATA[Ad title 2]]></AdTitle>
+      <Impression><![CDATA[http://example.com/impression1]]></Impression>
+      <Creatives>
+        <Creative id="vpaid">
+          <Linear skipoffset="00:00:10" >
+            <Duration>00:01:30.123</Duration>
+            <MediaFiles>
+              <MediaFile delivery="progressive" type="application/javascript" width="512" height="288" apiFramework="VPAID"><![CDATA[http://example.com/vpaid.js]]></MediaFile>
+            </MediaFiles>
+          </Linear>
+        </Creative>
+      </Creatives>
+    </InLine>
+  </Ad>
 </VAST>


### PR DESCRIPTION
I've made a mistake in the last release 😰 

While parsing an `<Ad>` node, I'm passing the `sequence` attribute value to the `Wrapper`/`Inline` children element: 
``` coffee
@parseAdElement: (adElement) ->
  for adTypeElement in adElement.childNodes
    continue unless adTypeElement.nodeName in ["Wrapper", "InLine"]

    adTypeElement.setAttribute "sequence", adElement.getAttribute("sequence") # <- HERE
```
The problem here is it'll always set `adTypeElement` `sequence` attribute value with what `adElement.getAttribute("sequence")` returns. If `adElement` doesn't have a `sequence` attribute, it'll return `null`. And so `adTypeElement` `sequence` attribute will be set with `"null"` (String) value.

This causes the VAST response `ad.sequence` property value to be `"null"` instead of `null`
