### PR TITLE
Bundle multiple customclick URLs from wrappers/inlines

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -147,6 +147,11 @@ class VASTParser
                                         if creative.type is 'linear'
                                             creative.videoClickTrackingURLTemplates = creative.videoClickTrackingURLTemplates.concat ad.videoClickTrackingURLTemplates
 
+                                if ad.videoCustomClickURLTemplates?
+                                    for creative in wrappedAd.creatives
+                                        if creative.type is 'linear'
+                                            creative.videoCustomClickURLTemplates = creative.videoCustomClickURLTemplates.concat ad.videoCustomClickURLTemplates
+
                                 # VAST 2.0 support - Use Wrapper/linear/clickThrough when Inline/Linear/clickThrough is null
                                 if ad.videoClickThroughURLTemplate?
                                     for creative in wrappedAd.creatives
@@ -207,6 +212,8 @@ class VASTParser
                         ad.videoClickTrackingURLTemplates = wrapperCreativeElement.videoClickTrackingURLTemplates
                     if wrapperCreativeElement.videoClickThroughURLTemplate?
                         ad.videoClickThroughURLTemplate = wrapperCreativeElement.videoClickThroughURLTemplate
+                    if wrapperCreativeElement.videoCustomClickURLTemplates?
+                        ad.videoCustomClickURLTemplates = wrapperCreativeElement.videoCustomClickURLTemplates
 
         if ad.nextWrapperURL?
             return ad

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -122,8 +122,8 @@ describe 'VASTParser', ->
                 it 'should have 5 URLs for clicktracking', =>
                     linear.videoClickTrackingURLTemplates.should.eql ['http://example.com/linear-clicktracking1', 'http://example.com/linear-clicktracking2', 'http://example.com/wrapperB-linear-clicktracking', 'http://example.com/wrapperA-linear-clicktracking1', 'http://example.com/wrapperA-linear-clicktracking2']
 
-                it 'should have 1 URL for customclick', =>
-                    linear.videoCustomClickURLTemplates.should.eql ['http://example.com/linear-customclick']
+                it 'should have 2 URLs for customclick', =>
+                    linear.videoCustomClickURLTemplates.should.eql ['http://example.com/linear-customclick', 'http://example.com/wrapperA-linear-customclick']
 
                 it 'should have 8 tracking events', =>
                     linear.trackingEvents.should.have.keys 'start', 'close', 'midpoint', 'complete', 'firstQuartile', 'thirdQuartile', 'progress-30', 'progress-60%'
@@ -296,6 +296,9 @@ describe 'VASTParser', ->
 
                 it 'should have wrapper clickthrough URL', =>
                     linear.videoClickThroughURLTemplate.should.eql "http://example.com/wrapperB-linear-clickthrough"
+
+                it 'should have wrapper customclick URL', =>
+                    linear.videoCustomClickURLTemplates.should.eql ["http://example.com/wrapperA-linear-customclick"]
 
                 it 'should have 4 URLs for clicktracking', =>
                     linear.videoClickTrackingURLTemplates.should.eql ['http://example.com/linear-clicktracking', 'http://example.com/wrapperB-linear-clicktracking', 'http://example.com/wrapperA-linear-clicktracking1', 'http://example.com/wrapperA-linear-clicktracking2']

--- a/test/wrapper_A.xml
+++ b/test/wrapper_A.xml
@@ -52,6 +52,7 @@
             <VideoClicks>
               <ClickTracking><![CDATA[http://example.com/wrapperA-linear-clicktracking1]]></ClickTracking>
               <ClickTracking><![CDATA[http://example.com/wrapperA-linear-clicktracking2]]></ClickTracking>
+              <CustomClick><![CDATA[http://example.com/wrapperA-linear-customclick]]></CustomClick>
             </VideoClicks>
           </Linear>
         </Creative>


### PR DESCRIPTION
Fix an old bug where we forgot to bundle `<CustomClick>` URLs while parsing wrappers / Inlines elements.