### PR TITLE
Add Support For Expand & Collapse events to Tracker

### DIFF
--- a/src/tracker.coffee
+++ b/src/tracker.coffee
@@ -90,6 +90,11 @@ class VASTTracker extends EventEmitter
             @track(if fullscreen then "fullscreen" else "exitFullscreen")
         @fullscreen = fullscreen
 
+    setExpand: (expanded) ->
+        if @expanded != expanded
+            @track(if expanded then "expand" else "collapse")
+        @expanded = expanded
+
     setSkipDelay: (duration) ->
         @skipDelay = duration if typeof duration is 'number'
 

--- a/test/tracker.coffee
+++ b/test/tracker.coffee
@@ -167,6 +167,34 @@ describe 'VASTTracker', ->
                 @Tracker.setFullscreen no
                 _eventsSent.should.eql []
 
+        describe '#setExpand', =>
+
+            before (done) =>
+                _eventsSent = []
+                @Tracker.trackingEvents['expand'] = 'http://example.com/expand'
+                @Tracker.trackingEvents['collapse'] = 'http://example.com/collapse'
+                @Tracker.setExpand yes
+                done()
+
+            it 'should be in expanded mode', =>
+                @Tracker.expanded.should.eql yes
+
+            it 'should send expand event', =>
+                _eventsSent.should.eql ["expand"]
+
+            it 'should be in collapsed mode', =>
+                _eventsSent = []
+                @Tracker.setExpand no
+                @Tracker.expanded.should.eql no
+
+            it 'should send collapse event', =>
+                _eventsSent.should.eql ["collapse"]
+
+            it 'should send no event', =>
+                _eventsSent = []
+                @Tracker.setExpand no
+                _eventsSent.should.eql []
+
 
         describe '#setSkipDelay', =>
 


### PR DESCRIPTION
These events are part of the VAST 2.0 spec, but were not currently
supported by the tracker. This adds the ability to fire these events by
calling the `setExpand` method with a boolean value for expanded or
collpased