### PR TITLE
Remove empty #text/ #comments node from parsed extensions

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -286,10 +286,13 @@ class VASTParser
                     ext.attributes[extNodeAttr.nodeName] = extNodeAttr.nodeValue;
 
             for childNode in extNode.childNodes
-                if childNode.nodeName != '#text'
+                txt = @parseNodeText(childNode)
+
+                # ignore comments / empty value
+                if childNode.nodeName isnt '#comment' and txt isnt ''
                     extChild = new VASTAdExtensionChild()
                     extChild.name = childNode.nodeName
-                    extChild.value = @parseNodeText(childNode)
+                    extChild.value = txt
 
                     if childNode.attributes
                         for extChildNodeAttr in childNode.attributes

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -93,7 +93,7 @@ describe 'VASTParser', ->
             it 'validate third extension', =>
                 ad1.extensions[2].attributes['type'].should.eql "Count"
                 ad1.extensions[2].children.should.have.length 1
-                ad1.extensions[2].children[0].name.should.eql "total_available"
+                ad1.extensions[2].children[0].name.should.eql "#cdata-section"
                 ad1.extensions[2].children[0].value.should.eql "4"
 
             #Linear

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -72,8 +72,8 @@ describe 'VASTParser', ->
             it 'should have 3 creatives', =>
                 ad1.creatives.should.have.length 3
 
-            it 'should have 3 extensions', =>
-                ad1.extensions.should.have.length 3
+            it 'should have 4 extensions', =>
+                ad1.extensions.should.have.length 4
 
             it 'validate first extension', =>
                 ad1.extensions[0].attributes['type'].should.eql "WrapperExtension"
@@ -95,6 +95,12 @@ describe 'VASTParser', ->
                 ad1.extensions[2].children.should.have.length 1
                 ad1.extensions[2].children[0].name.should.eql "#cdata-section"
                 ad1.extensions[2].children[0].value.should.eql "4"
+
+            it 'validate fourth extension', =>
+                ad1.extensions[3].attributes.should.eql {}
+                ad1.extensions[3].children.should.have.length 1
+                ad1.extensions[3].children[0].name.should.eql "#text"
+                ad1.extensions[3].children[0].value.should.eql "{ foo: bar }"
 
             #Linear
             describe '1st creative (Linear)', ->

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -104,9 +104,8 @@
           </Price>
         </Extension>
         <Extension type="Count">
-          <total_available>
-            <![CDATA[ 4 ]]>
-          </total_available>
+          <!-- -->
+          <![CDATA[ 4 ]]>
         </Extension>
       </Extensions>
     </InLine>

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -107,6 +107,9 @@
           <!-- -->
           <![CDATA[ 4 ]]>
         </Extension>
+        <Extension>
+            { foo: bar }
+        </Extension>
       </Extensions>
     </InLine>
   </Ad>


### PR DESCRIPTION
While parsing `<Extensions>` nodes,  the parser was creating an `extension` object for every `#comment` or empty `#text` nodes found.

They are now ignored an only non-empty `#text` node or `xml` node are saved.