### PR TITLE
Parse all nonlinear attributes

### DIFF
--- a/src/nonlinear.coffee
+++ b/src/nonlinear.coffee
@@ -3,7 +3,11 @@ class VASTNonLinear
         @id = null
         @width = 0
         @height = 0
-        @minSuggestedDuration = "00:00:00"
+        @expandedWidth = 0
+        @expandedHeight = 0
+        @scalable = true
+        @maintainAspectRatio = true
+        @minSuggestedDuration = 0
         @apiFramework = "static"
         @type = null
         @staticResource = null

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -425,7 +425,11 @@ class VASTParser
             nonlinearAd.id = nonlinearResource.getAttribute("id") or null
             nonlinearAd.width = nonlinearResource.getAttribute("width")
             nonlinearAd.height = nonlinearResource.getAttribute("height")
-            nonlinearAd.minSuggestedDuration = nonlinearResource.getAttribute("minSuggestedDuration")
+            nonlinearAd.expandedWidth = nonlinearResource.getAttribute("expandedWidth")
+            nonlinearAd.expandedHeight = nonlinearResource.getAttribute("expandedHeight")
+            nonlinearAd.scalable = @parseBoolean nonlinearResource.getAttribute("scalable")
+            nonlinearAd.maintainAspectRatio = @parseBoolean nonlinearResource.getAttribute("maintainAspectRatio")
+            nonlinearAd.minSuggestedDuration = @parseDuration nonlinearResource.getAttribute("minSuggestedDuration")
             nonlinearAd.apiFramework = nonlinearResource.getAttribute("apiFramework")
 
             for htmlElement in @childsByName(nonlinearResource, "HTMLResource")
@@ -508,6 +512,9 @@ class VASTParser
             return yPosition
 
         return parseInt yPosition or 0
+
+    @parseBoolean: (booleanString) ->
+            return booleanString in ['true', 'TRUE', '1']
 
     # Parsing node text for legacy support
     @parseNodeText: (node) ->

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -286,9 +286,15 @@ describe 'VASTParser', ->
                         after () =>
                             nonlinear = null
 
-                        it 'should have parsed size and type attributes', =>
+                        it 'should have parsed attributes', =>
                             nonlinear.width.should.equal '300'
                             nonlinear.height.should.equal '200'
+                            nonlinear.expandedWidth.should.equal '600'
+                            nonlinear.expandedHeight.should.equal '400'
+                            nonlinear.scalable.should.equal false
+                            nonlinear.maintainAspectRatio.should.equal true
+                            nonlinear.minSuggestedDuration.should.equal 100
+                            nonlinear.apiFramework.should.equal "someAPI"
                             nonlinear.type.should.equal 'image/jpeg'
 
                         it 'should have 1 nonlinear clickthrough url', =>

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -82,7 +82,7 @@
         </Creative>
         <Creative>
           <NonLinearAds>
-            <NonLinear width="300" height="200">
+            <NonLinear width="300" height="200" expandedWidth="600" expandedHeight="400" scalable="false" maintainAspectRatio="true" minSuggestedDuration="00:01:40" apiFramework="someAPI" >
               <StaticResource creativeType="image/jpeg"><![CDATA[http://example.com/nonlinear-static-resource]]></StaticResource>
               <NonLinearClickThrough><![CDATA[http://example.com/nonlinear-clickthrough]]></NonLinearClickThrough>
             </NonLinear>


### PR DESCRIPTION
Parse and return `<nonlinear>` attributes:
- expandedWidth
- expandedHeight
- scalable
- maintainAspectRatio

Also convert `<nonlinear>` `minSuggestedDuration` value to second (as we do with `<linear><duration>` value).