### PR TITLE
Return creative id, adId, sequence and apiFramework attributes

### DIFF
--- a/src/creative.coffee
+++ b/src/creative.coffee
@@ -1,5 +1,9 @@
 class VASTCreative
-    constructor: ->
+    constructor: (creativeAttributes = {}) ->
+        @id = creativeAttributes.id or null
+        @adId = creativeAttributes.adId or null
+        @sequence = creativeAttributes.sequence or null
+        @apiFramework = creativeAttributes.apiFramework or null
         @trackingEvents = {}
 
 class VASTCreativeLinear extends VASTCreative
@@ -23,6 +27,7 @@ class VASTCreativeNonLinear extends VASTCreative
 
 class VASTCreativeCompanion extends VASTCreative
     constructor: ->
+        super
         @type = "companion"
         @variations = []
 

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -235,18 +235,24 @@ class VASTParser
 
                 when "Creatives"
                     for creativeElement in @childsByName(node, "Creative")
+                        creativeAttributes =
+                            id           : creativeElement.getAttribute('id') or null
+                            adId         : creativeElement.getAttribute('adId') or null
+                            sequence     : creativeElement.getAttribute('sequence') or null
+                            apiFramework : creativeElement.getAttribute('apiFramework') or null
+
                         for creativeTypeElement in creativeElement.childNodes
                             switch creativeTypeElement.nodeName
                                 when "Linear"
-                                    creative = @parseCreativeLinearElement creativeTypeElement
+                                    creative = @parseCreativeLinearElement creativeTypeElement, creativeAttributes
                                     if creative
                                         ad.creatives.push creative
                                 when "NonLinearAds"
-                                    creative = @parseNonLinear creativeTypeElement
+                                    creative = @parseNonLinear creativeTypeElement, creativeAttributes
                                     if creative
                                         ad.creatives.push creative
                                 when "CompanionAds"
-                                    creative = @parseCompanionAd creativeTypeElement
+                                    creative = @parseCompanionAd creativeTypeElement, creativeAttributes
                                     if creative
                                         ad.creatives.push creative
                 when "Extensions"
@@ -302,8 +308,8 @@ class VASTParser
 
             collection.push ext
 
-    @parseCreativeLinearElement: (creativeElement) ->
-        creative = new VASTCreativeLinear()
+    @parseCreativeLinearElement: (creativeElement, creativeAttributes) ->
+        creative = new VASTCreativeLinear(creativeAttributes)
 
         creative.duration = @parseDuration @parseNodeText(@childByName(creativeElement, "Duration"))
         if creative.duration == -1 and creativeElement.parentNode.parentNode.parentNode.nodeName != 'Wrapper'
@@ -412,8 +418,8 @@ class VASTParser
 
         return creative
 
-    @parseNonLinear: (creativeElement) ->
-        creative = new VASTCreativeNonLinear()
+    @parseNonLinear: (creativeElement, creativeAttributes) ->
+        creative = new VASTCreativeNonLinear(creativeAttributes)
 
         for trackingEventsElement in @childsByName(creativeElement, "TrackingEvents")
           for trackingElement in @childsByName(trackingEventsElement, "Tracking")
@@ -452,8 +458,8 @@ class VASTParser
 
         return creative
 
-    @parseCompanionAd: (creativeElement) ->
-        creative = new VASTCreativeCompanion()
+    @parseCompanionAd: (creativeElement, creativeAttributes) ->
+        creative = new VASTCreativeCompanion(creativeAttributes)
 
         for companionResource in @childsByName(creativeElement, "Companion")
             companionAd = new VASTCompanionAd()

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -122,6 +122,18 @@ describe 'VASTParser', ->
                 it 'should have linear type', =>
                     linear.type.should.equal "linear"
 
+                it 'should have an id', =>
+                    linear.id.should.equal "id130984"
+
+                it 'should have an adId', =>
+                    linear.adId.should.equal "adId345690"
+
+                it 'should have a sequence', =>
+                    linear.sequence.should.equal "1"
+
+                it 'should not have an apiFramework', =>
+                    should.equal linear.apiFramework, null
+
                 it 'should have a duration of 90.123s', =>
                     linear.duration.should.equal 90.123
 
@@ -193,6 +205,18 @@ describe 'VASTParser', ->
 
                 it 'should have companion type', =>
                     companions.type.should.equal "companion"
+
+                it 'should have an id', =>
+                    companions.id.should.equal "id130985"
+
+                it 'should have an adId', =>
+                    companions.adId.should.equal "adId345691"
+
+                it 'should have a sequence', =>
+                    companions.sequence.should.equal "2"
+
+                it 'should not have an apiFramework', =>
+                    should.equal companions.apiFramework, null
 
                 it 'should have 3 variations', =>
                     companions.variations.should.have.length 3
@@ -286,6 +310,18 @@ describe 'VASTParser', ->
 
                 it 'should have nonlinear type', =>
                     nonlinears.type.should.equal "nonlinear"
+
+                it 'should not have an id', =>
+                    should.equal nonlinears.id, null
+
+                it 'should not have an adId', =>
+                    should.equal nonlinears.adId, null
+
+                it 'should not have a sequence', =>
+                    should.equal nonlinears.sequence, null
+
+                it 'should not have an apiFramework', =>
+                    should.equal nonlinears.apiFramework, null
 
                 it 'should have 1 variation', =>
                     nonlinears.variations.should.have.length 1
@@ -381,6 +417,18 @@ describe 'VASTParser', ->
 
                 it 'should have linear type', =>
                     linear.type.should.equal "linear"
+
+                it 'should have an id', =>
+                    linear.id.should.equal "id873421"
+
+                it 'should not have an adId', =>
+                    should.equal linear.adId, null
+
+                it 'should not have a sequence', =>
+                    should.equal linear.sequence, null
+
+                it 'should have an apiFramework', =>
+                    linear.apiFramework.should.equal "VPAID"
 
                 it 'should have a duration of 30.123s', =>
                     linear.duration.should.equal 30.123

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -14,7 +14,7 @@
       <Impression><![CDATA[http://example.com/impression2_[random]]]></Impression>
       <Impression><![CDATA[http://example.com/impression3_[RANDOM]]]></Impression>
       <Creatives>
-        <Creative id="video">
+        <Creative id="id130984" adId="adId345690" sequence="1" >
           <Linear>
             <Duration>00:01:30.123</Duration>
             <TrackingEvents>
@@ -49,7 +49,7 @@
             </Icons>
           </Linear>
         </Creative>
-        <Creative>
+        <Creative id="id130985" adId="adId345691" sequence="2" >
           <CompanionAds>
             <Companion width="300" height="60">
               <StaticResource creativeType="image/jpeg"><![CDATA[http://example.com/companion1-static-resource]]></StaticResource>
@@ -123,7 +123,7 @@
       <AdTitle><![CDATA[Ad title 2]]></AdTitle>
       <Impression><![CDATA[http://example.com/impression1]]></Impression>
       <Creatives>
-        <Creative id="vpaid">
+        <Creative id="id873421" apiFramework="VPAID">
           <Linear skipoffset="00:00:10" >
             <Duration>00:00:30.123</Duration>
             <MediaFiles>


### PR DESCRIPTION
The VAST parser now returns Creative `id`, `adId`, `sequence` and `apiFramework` attributes.