### PR TITLE
Handle VAST2/3/4 creative adId format

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -237,7 +237,7 @@ class VASTParser
                     for creativeElement in @childsByName(node, "Creative")
                         creativeAttributes =
                             id           : creativeElement.getAttribute('id') or null
-                            adId         : creativeElement.getAttribute('adId') or null
+                            adId         : @parseCreativeAdIdAttribute(creativeElement)
                             sequence     : creativeElement.getAttribute('sequence') or null
                             apiFramework : creativeElement.getAttribute('apiFramework') or null
 
@@ -546,5 +546,11 @@ class VASTParser
         attributeValue = nodeSource.getAttribute attributeName
         if attributeValue
             nodeDestination.setAttribute attributeName, attributeValue
+
+    @parseCreativeAdIdAttribute: (creativeElement) ->
+        return creativeElement.getAttribute('AdID') or  # VAST 2 spec
+               creativeElement.getAttribute('adID') or  # VAST 3 spec
+               creativeElement.getAttribute('adId') or  # VAST 4 spec
+               null
 
 module.exports = VASTParser

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -422,8 +422,8 @@ describe 'VASTParser', ->
                 it 'should have an id', =>
                     linear.id.should.equal "id873421"
 
-                it 'should not have an adId', =>
-                    should.equal linear.adId, null
+                it 'should have an adId', =>
+                    linear.adId.should.equal "adId221144"
 
                 it 'should not have a sequence', =>
                     should.equal linear.sequence, null

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -49,7 +49,7 @@
             </Icons>
           </Linear>
         </Creative>
-        <Creative id="id130985" adId="adId345691" sequence="2" >
+        <Creative id="id130985" AdID="adId345691" sequence="2" >
           <CompanionAds>
             <Companion width="300" height="60">
               <StaticResource creativeType="image/jpeg"><![CDATA[http://example.com/companion1-static-resource]]></StaticResource>
@@ -125,7 +125,7 @@
       <AdTitle><![CDATA[Ad title 2]]></AdTitle>
       <Impression><![CDATA[http://example.com/impression1]]></Impression>
       <Creatives>
-        <Creative id="id873421" apiFramework="VPAID">
+        <Creative id="id873421" adID="adId221144" apiFramework="VPAID">
           <Linear skipoffset="00:00:10" >
             <Duration>30</Duration>
             <MediaFiles>


### PR DESCRIPTION
Creative `adId` attribute can be found in 3 differents formats depemding on the VAST specification:
- `AdID` in [VAST 2.0](http://www.iab.com/wp-content/uploads/2015/11/VAST-2_0-FINAL.pdf#page=11)
- `adID` in [VAST 3.0](https://www.iab.com/wp-content/uploads/2015/06/VASTv3_0.pdf#page=67)
- `adId` in [VAST 4.0](http://www.iab.com/wp-content/uploads/2016/04/VAST4.0_Updated_April_2016.pdf#page=39)

this PR will parse any of the theses 3 formats.