### PR TITLE
Handle tracking events when defined in 2 creatives of the same type

### DIFF
--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -109,6 +109,18 @@ describe 'VASTParser', ->
                 ad1.extensions[3].children[0].name.should.eql "#text"
                 ad1.extensions[3].children[0].value.should.eql "{ foo: bar }"
 
+            it 'should not have trackingEvents property', =>
+                should.equal ad1.trackingEvents, undefined
+
+            it 'should not have videoClickTrackingURLTemplates property', =>
+                should.equal ad1.videoClickTrackingURLTemplates, undefined
+
+            it 'should not have videoClickThroughURLTemplate property', =>
+                should.equal ad1.videoClickThroughURLTemplate, undefined
+
+            it 'should not have videoCustomClickURLTemplates property', =>
+                should.equal ad1.videoCustomClickURLTemplates, undefined
+
             #Linear
             describe '1st creative (Linear)', ->
                 linear = null
@@ -156,7 +168,8 @@ describe 'VASTParser', ->
                         'http://example.com/linear-clicktracking2',
                         'http://example.com/wrapperB-linear-clicktracking',
                         'http://example.com/wrapperA-linear-clicktracking1',
-                        'http://example.com/wrapperA-linear-clicktracking2'
+                        'http://example.com/wrapperA-linear-clicktracking2',
+                        'http://example.com/wrapperA-linear-clicktracking3'
                     ]
 
                 it 'should have 2 URLs for customclick', =>
@@ -165,17 +178,39 @@ describe 'VASTParser', ->
                 it 'should have 8 tracking events', =>
                     linear.trackingEvents.should.have.keys 'start', 'close', 'midpoint', 'complete', 'firstQuartile', 'thirdQuartile', 'progress-30', 'progress-60%'
 
-                it 'should have 3 URLs for start event', =>
-                    linear.trackingEvents['start'].should.eql ['http://example.com/linear-start', 'http://example.com/wrapperB-linear-start', 'http://example.com/wrapperA-linear-start']
+                it 'should have 4 URLs for start event', =>
+                    linear.trackingEvents['start'].should.eql [
+                        'http://example.com/linear-start',
+                        'http://example.com/wrapperB-linear-start',
+                        'http://example.com/wrapperA-linear-start1',
+                        'http://example.com/wrapperA-linear-start2'
+                    ]
 
                 it 'should have 3 URLs for complete event', =>
-                    linear.trackingEvents['complete'].should.eql ['http://example.com/linear-complete', 'http://example.com/wrapperB-linear-complete', 'http://example.com/wrapperA-linear-complete']
+                    linear.trackingEvents['complete'].should.eql [
+                        'http://example.com/linear-complete',
+                        'http://example.com/wrapperB-linear-complete',
+                        'http://example.com/wrapperA-linear-complete'
+                    ]
 
                 it 'should have 3 URLs for progress-30 event VAST 3.0', =>
-                    linear.trackingEvents['progress-30'].should.eql ['http://example.com/linear-progress-30sec', 'http://example.com/wrapperB-linear-progress-30sec', 'http://example.com/wrapperA-linear-progress-30sec']
+                    linear.trackingEvents['progress-30'].should.eql [
+                        'http://example.com/linear-progress-30sec',
+                        'http://example.com/wrapperB-linear-progress-30sec',
+                        'http://example.com/wrapperA-linear-progress-30sec'
+                    ]
 
                 it 'should have 3 URLs for progress-60% event VAST 3.0', =>
-                    linear.trackingEvents['progress-60%'].should.eql ['http://example.com/linear-progress-60%', 'http://example.com/wrapperB-linear-progress-60%', 'http://example.com/wrapperA-linear-progress-60%']
+                    linear.trackingEvents['progress-60%'].should.eql [
+                        'http://example.com/linear-progress-60%',
+                        'http://example.com/wrapperB-linear-progress-60%',
+                        'http://example.com/wrapperA-linear-progress-60%'
+                    ]
+
+                it 'should have 3 URLs for progress-90% event VAST 3.0', =>
+                    linear.trackingEvents['progress-90%'].should.eql [
+                        'http://example.com/wrapperA-linear-progress-90%'
+                    ]
 
                 it 'should have parsed icons element', =>
                     icon = linear.icons[0]
@@ -242,7 +277,7 @@ describe 'VASTParser', ->
 
                         it 'should have 1 url for creativeView event', =>
                             companion.trackingEvents['creativeView'].should.eql ['http://example.com/companion1-creativeview']
-				       
+
                         it 'should have checked that AltText exists', =>
                             companion.should.have.property('altText')
 
@@ -440,8 +475,14 @@ describe 'VASTParser', ->
                 it 'should have wrapper customclick URL', =>
                     linear.videoCustomClickURLTemplates.should.eql ["http://example.com/wrapperA-linear-customclick"]
 
-                it 'should have 4 URLs for clicktracking', =>
-                    linear.videoClickTrackingURLTemplates.should.eql ['http://example.com/linear-clicktracking', 'http://example.com/wrapperB-linear-clicktracking', 'http://example.com/wrapperA-linear-clicktracking1', 'http://example.com/wrapperA-linear-clicktracking2']
+                it 'should have 5 URLs for clicktracking', =>
+                    linear.videoClickTrackingURLTemplates.should.eql [
+                        'http://example.com/linear-clicktracking',
+                        'http://example.com/wrapperB-linear-clicktracking',
+                        'http://example.com/wrapperA-linear-clicktracking1',
+                        'http://example.com/wrapperA-linear-clicktracking2',
+                        'http://example.com/wrapperA-linear-clicktracking3'
+                    ]
 
 
         describe '#VAST', ->

--- a/test/tracker.coffee
+++ b/test/tracker.coffee
@@ -319,7 +319,8 @@ describe 'VASTTracker', ->
                         'http://example.com/linear-clicktracking2',
                         'http://example.com/wrapperB-linear-clicktracking',
                         'http://example.com/wrapperA-linear-clicktracking1',
-                        'http://example.com/wrapperA-linear-clicktracking2'
+                        'http://example.com/wrapperA-linear-clicktracking2',
+                        'http://example.com/wrapperA-linear-clicktracking3'
                     ]
 
                 it 'should have sent clickthrough event', =>

--- a/test/wrapper_A.xml
+++ b/test/wrapper_A.xml
@@ -44,7 +44,7 @@
         <Creative>
           <Linear>
             <TrackingEvents>
-              <Tracking event="start"><![CDATA[http://example.com/wrapperA-linear-start]]></Tracking>
+              <Tracking event="start"><![CDATA[http://example.com/wrapperA-linear-start1]]></Tracking>
               <Tracking event="progress" offset="00:00:30"><![CDATA[http://example.com/wrapperA-linear-progress-30sec]]></Tracking>
               <Tracking event="progress" offset="60%"><![CDATA[http://example.com/wrapperA-linear-progress-60%]]></Tracking>
               <Tracking event="complete"><![CDATA[http://example.com/wrapperA-linear-complete]]></Tracking>
@@ -53,6 +53,17 @@
               <ClickTracking><![CDATA[http://example.com/wrapperA-linear-clicktracking1]]></ClickTracking>
               <ClickTracking><![CDATA[http://example.com/wrapperA-linear-clicktracking2]]></ClickTracking>
               <CustomClick><![CDATA[http://example.com/wrapperA-linear-customclick]]></CustomClick>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+        <Creative>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start"><![CDATA[http://example.com/wrapperA-linear-start2]]></Tracking>
+              <Tracking event="progress" offset="90%"><![CDATA[http://example.com/wrapperA-linear-progress-90%]]></Tracking>
+            </TrackingEvents>
+            <VideoClicks>
+              <ClickTracking><![CDATA[http://example.com/wrapperA-linear-clicktracking3]]></ClickTracking>
             </VideoClicks>
           </Linear>
         </Creative>


### PR DESCRIPTION
Two or more `<Linear>` can be found in a `<Wrapper>` tag. ie:

``` xml
<Creatives>
  <Creative id="crea1">
    <Linear>
      <TrackingEvents>
        <Tracking event="start">
          <![CDATA[https://example.dailymotion.com/track/start1]]>
        </Tracking>
      </TrackingEvents>
    </Linear>
  </Creative>
  <Creative id="crea2">
    <Linear>
      <TrackingEvents>
        <Tracking event="start">
          <![CDATA[https://example.dailymotion.com/track/start2]]>
        </Tracking>
      </TrackingEvents>
    </Linear>
  </Creative>
</Creatives>
```

 Right now, the VAST Client only use the data from the last `<linear>`. Thus the `start1` pixel is ignored.

This PR  will update the VAST parser to merge all `<Creative>` tracking/URLs the VAST file has.