### PR TITLE
Fix parsing error when wrapper has no trackingEvents defined

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -106,13 +106,8 @@ class VASTParser
                         complete(new Error("Wrapper limit reached, as defined by the video player"))
                         return
 
-                    if ad.nextWrapperURL.indexOf('//') == 0
-                      protocol = location.protocol
-                      ad.nextWrapperURL = "#{protocol}#{ad.nextWrapperURL}"
-                    else if ad.nextWrapperURL.indexOf('://') == -1
-                        # Resolve relative URLs (mainly for unit testing)
-                        baseURL = url.slice(0, url.lastIndexOf('/'))
-                        ad.nextWrapperURL = "#{baseURL}/#{ad.nextWrapperURL}"
+                    # Get full URL
+                    ad.nextWrapperURL = @resolveVastAdTagURI(ad.nextWrapperURL, url)
 
                     @_parse ad.nextWrapperURL, parentURLs, options, (err, wrappedResponse) =>
                         errorAlreadyRaised = false
@@ -131,39 +126,56 @@ class VASTParser
                             response.errorURLTemplates = response.errorURLTemplates.concat wrappedResponse.errorURLTemplates
                             index = response.ads.indexOf(ad)
                             response.ads.splice(index, 1)
+
                             for wrappedAd in wrappedResponse.ads
-                                wrappedAd.errorURLTemplates = ad.errorURLTemplates.concat wrappedAd.errorURLTemplates
-                                wrappedAd.impressionURLTemplates = ad.impressionURLTemplates.concat wrappedAd.impressionURLTemplates
-                                wrappedAd.extensions = ad.extensions.concat wrappedAd.extensions
-
-                                for creative in wrappedAd.creatives
-                                    if ad.trackingEvents[creative.type]?
-                                        for eventName, urls of ad.trackingEvents[creative.type]
-                                            creative.trackingEvents[eventName] or= []
-                                            creative.trackingEvents[eventName] = creative.trackingEvents[eventName].concat urls
-
-                                if ad.videoClickTrackingURLTemplates.length
-                                    for creative in wrappedAd.creatives
-                                        if creative.type is 'linear'
-                                            creative.videoClickTrackingURLTemplates = creative.videoClickTrackingURLTemplates.concat ad.videoClickTrackingURLTemplates
-
-                                if ad.videoCustomClickURLTemplates.length
-                                    for creative in wrappedAd.creatives
-                                        if creative.type is 'linear'
-                                            creative.videoCustomClickURLTemplates = creative.videoCustomClickURLTemplates.concat ad.videoCustomClickURLTemplates
-
-                                # VAST 2.0 support - Use Wrapper/linear/clickThrough when Inline/Linear/clickThrough is null
-                                if ad.videoClickThroughURLTemplate?
-                                    for creative in wrappedAd.creatives
-                                        if creative.type is 'linear' and not creative.videoClickThroughURLTemplate?
-                                            creative.videoClickThroughURLTemplate = ad.videoClickThroughURLTemplate
-
+                                @mergeWrapperAdData wrappedAd, ad
                                 response.ads.splice ++index, 0, wrappedAd
 
                         delete ad.nextWrapperURL
                         complete err, errorAlreadyRaised
 
             complete()
+
+    # Convert relative vastAdTagUri
+    @resolveVastAdTagURI: (vastAdTagUrl, originalUrl) ->
+        if vastAdTagUrl.indexOf('//') == 0
+            protocol = location.protocol
+            return "#{protocol}#{vastAdTagUrl}"
+
+        if vastAdTagUrl.indexOf('://') == -1
+            # Resolve relative URLs (mainly for unit testing)
+            baseURL = originalUrl.slice(0, originalUrl.lastIndexOf('/'))
+            return "#{baseURL}/#{vastAdTagUrl}"
+
+        return vastAdTagUrl
+
+    # Merge ad tracking URLs / extensions data into wrappedAd
+    @mergeWrapperAdData: (wrappedAd, ad) ->
+        wrappedAd.errorURLTemplates = ad.errorURLTemplates.concat wrappedAd.errorURLTemplates
+        wrappedAd.impressionURLTemplates = ad.impressionURLTemplates.concat wrappedAd.impressionURLTemplates
+        wrappedAd.extensions = ad.extensions.concat wrappedAd.extensions
+
+        for creative in wrappedAd.creatives
+            if ad.trackingEvents?[creative.type]?
+                for eventName, urls of ad.trackingEvents[creative.type]
+                    creative.trackingEvents[eventName] or= []
+                    creative.trackingEvents[eventName] = creative.trackingEvents[eventName].concat urls
+
+        if ad.videoClickTrackingURLTemplates?.length
+            for creative in wrappedAd.creatives
+                if creative.type is 'linear'
+                    creative.videoClickTrackingURLTemplates = creative.videoClickTrackingURLTemplates.concat ad.videoClickTrackingURLTemplates
+
+        if ad.videoCustomClickURLTemplates?.length
+            for creative in wrappedAd.creatives
+                if creative.type is 'linear'
+                    creative.videoCustomClickURLTemplates = creative.videoCustomClickURLTemplates.concat ad.videoCustomClickURLTemplates
+
+        # VAST 2.0 support - Use Wrapper/linear/clickThrough when Inline/Linear/clickThrough is null
+        if ad.videoClickThroughURLTemplate?
+            for creative in wrappedAd.creatives
+                if creative.type is 'linear' and not creative.videoClickThroughURLTemplate?
+                    creative.videoClickThroughURLTemplate = ad.videoClickThroughURLTemplate
 
     @childByName: (node, name) ->
         for child in node.childNodes

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -16,7 +16,7 @@ describe 'VASTParser', ->
             VASTParser.addURLTemplateFilter (url) =>
               @templateFilterCalls.push url
               return url
-            VASTParser.parse urlfor('wrapper_A.xml'), (@response) =>
+            VASTParser.parse urlfor('wrapper_notracking.xml'), (@response) =>
                 _response = @response
                 done()
 
@@ -26,9 +26,9 @@ describe 'VASTParser', ->
         it 'should have 1 filter defined', =>
             VASTParser.countURLTemplateFilters().should.equal 1
 
-        it 'should have called 3 times URLtemplateFilter ', =>
-            @templateFilterCalls.should.have.length 3
-            @templateFilterCalls.should.eql [urlfor('wrapper_A.xml'), urlfor('wrapper_B.xml'), urlfor('sample.xml')]
+        it 'should have called 4 times URLtemplateFilter ', =>
+            @templateFilterCalls.should.have.length 4
+            @templateFilterCalls.should.eql [urlfor('wrapper_notracking.xml'), urlfor('wrapper_A.xml'), urlfor('wrapper_B.xml'), urlfor('sample.xml')]
 
         it 'should have found 2 ads', =>
             @response.ads.should.have.length 2
@@ -64,10 +64,16 @@ describe 'VASTParser', ->
                 ad1.survey.should.eql "http://example.com/survey"
 
             it 'should have merged wrapped ad error URLs', =>
-                ad1.errorURLTemplates.should.eql ["http://example.com/wrapperA-error", "http://example.com/wrapperB-error", "http://example.com/error_[ERRORCODE]"]
+                ad1.errorURLTemplates.should.eql [
+                    "http://example.com/wrapperNoTracking-error",
+                    "http://example.com/wrapperA-error",
+                    "http://example.com/wrapperB-error",
+                    "http://example.com/error_[ERRORCODE]"
+                ]
 
             it 'should have merged impression URLs', =>
                 ad1.impressionURLTemplates.should.eql [
+                    "http://example.com/wrapperNoTracking-impression",
                     "http://example.com/wrapperA-impression",
                     "http://example.com/wrapperB-impression1",
                     "http://example.com/wrapperB-impression2",
@@ -424,10 +430,20 @@ describe 'VASTParser', ->
                 should.equal ad2.survey, null
 
             it 'should have merged error URLs', =>
-                ad2.errorURLTemplates.should.eql ["http://example.com/wrapperA-error", "http://example.com/wrapperB-error"]
+                ad2.errorURLTemplates.should.eql [
+                    "http://example.com/wrapperNoTracking-error",
+                    "http://example.com/wrapperA-error",
+                    "http://example.com/wrapperB-error"
+                ]
 
             it 'should have merged impression URLs', =>
-                ad2.impressionURLTemplates.should.eql ["http://example.com/wrapperA-impression", "http://example.com/wrapperB-impression1", "http://example.com/wrapperB-impression2", "http://example.com/impression1"]
+                ad2.impressionURLTemplates.should.eql [
+                    "http://example.com/wrapperNoTracking-impression",
+                    "http://example.com/wrapperA-impression",
+                    "http://example.com/wrapperB-impression1",
+                    "http://example.com/wrapperB-impression2",
+                    "http://example.com/impression1"
+                ]
 
             it 'should have 1 creative', =>
                 ad2.creatives.should.have.length 1

--- a/test/wrapper_notracking.xml
+++ b/test/wrapper_notracking.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<VAST version="2.0">
+  <Ad>
+    <Wrapper>
+      <AdSystem>VAST</AdSystem>
+      <VASTAdTagURI>wrapper_A.xml</VASTAdTagURI>
+      <Error>http://example.com/wrapperNoTracking-error</Error>
+      <Impression>http://example.com/wrapperNoTracking-impression</Impression>
+    </Wrapper>
+  </Ad>
+</VAST>


### PR DESCRIPTION
Bug introduced in #170 

TheVAST parser is throwing a JS error when the following happen:
- No `<creative><trackingEvents>` defined
- No `<creative><videoClickTrackingURLTemplates>` defined
- No `<creative><videoCustomClickURLTemplates>` defined

This should fix it.