### PR TITLE
Remove output to console.log in test

### DIFF
--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -533,7 +533,6 @@ describe 'VASTParser', ->
                                         break
                 VASTParser.load xml, (err, response) =>
                     @response = response
-                    console.log response.ads[0]
                     done()
 
         after () =>


### PR DESCRIPTION
Clean up output to console.log accidentally included in the previouly merged PR.