### PR TITLE
Add new events resolving/resolved while parsing VastAdTagUri

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -70,7 +70,11 @@ class VASTParser
         parentURLs ?= []
         parentURLs.push url
 
+        @vent.emit 'resolving', { url: url }
+
         URLHandler.get url, options, (err, xml) =>
+            @vent.emit 'resolved', { url: url }
+
             return cb(err) if err?
             @parseXmlDocument(url, parentURLs, options, xml, cb)
 


### PR DESCRIPTION
New events `resolving` / `resolved` are emitted while parsing the VAST. `resolving` is triggered before calling the URL/VASTAdTagURI and `resolving` once done.