### PR TITLE
Fix #156 : Add "browser" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "node": ">=0.10.26"
   },
   "main": "dist/index.js",
+  "browser": "vast-client.js",
   "scripts": {
     "test": "mocha --compilers coffee:coffee-script/register --reporter spec test/*.coffee",
     "bundle": "browserify -s DMVAST -c 'coffee -scb' --extension=.coffee src/index.coffee -o vast-client.js",


### PR DESCRIPTION
Fixes #156.
Reading [npm](https://docs.npmjs.com/files/package.json#main) and [webpack](https://webpack.js.org/configuration/resolve/#resolve-mainfields) documentations, it appears that `main` field should be kept as it is so the package stays compatible with Node.JS. 

I only added a new `"browser"` field, which is enough for webpack to use the built version by default.