### PR TITLE
Return request object from urlhandlers

### DIFF
--- a/src/urlhandlers/flash.coffee
+++ b/src/urlhandlers/flash.coffee
@@ -24,4 +24,6 @@ class FlashURLHandler
              xmlDocument.loadXML(xdr.responseText)
              cb(null, xmlDocument)
 
+        return xdr
+
 module.exports = FlashURLHandler

--- a/src/urlhandlers/node.coffee
+++ b/src/urlhandlers/node.coffee
@@ -37,4 +37,6 @@ class NodeURLHandler
             fn = timeout_wrapper req
             timing = setTimeout( fn, options.timeout or 120000 );
 
+            return req;
+
 module.exports = NodeURLHandler

--- a/src/urlhandlers/xmlhttprequest.coffee
+++ b/src/urlhandlers/xmlhttprequest.coffee
@@ -24,6 +24,7 @@ class XHRURLHandler
                     else
                         cb(new Error("XHRURLHandler: #{xhr.statusText}"))
             xhr.send()
+            return xhr;
         catch
             cb(new Error('XHRURLHandler: Unexpected error'))
 


### PR DESCRIPTION
When unmounting a component that makes a request we need to be able to abort the request. Coffeescript has an implicit return on the last line, and was returning the result from the send method for the xhr request. 

This instead returns the xhr request so that anything calling `client.get` is free to `xhr.abort()` the request preventing the callback from firing. 

I took a stab at the flash and node handlers, however I wasn't sure if the same approach was appropriate for those. Let me know if its not and I'll back those changes out. 

There should be an ability to abort xhr requests if necessary, currently that ability does not exist.  