### PR TITLE
Sequence persists for wrapper ad

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -83,7 +83,8 @@ class VASTParser
             if node.nodeName is 'Ad'
                 ad = @parseAdElement node
                 if ad?
-                    if options.determinedSequence?
+                    if options.determinedSequence? and not ad.sequence?
+                        # Set sequence from wrapper if there isn't one on the ad
                         ad.sequence = options.determinedSequence
 
                     response.ads.push ad

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -83,6 +83,9 @@ class VASTParser
             if node.nodeName is 'Ad'
                 ad = @parseAdElement node
                 if ad?
+                    if options.determinedSequence?
+                        ad.sequence = options.determinedSequence
+
                     response.ads.push ad
                 else
                     # VAST version of response not supported.
@@ -123,6 +126,8 @@ class VASTParser
                     # Get full URL if url is defined
                     ad.nextWrapperURL = @resolveVastAdTagURI(ad.nextWrapperURL, url)
 
+                 # sequence doesn't carry over in wrapper element
+                options.determinedSequence = ad.sequence
                 @_parse ad.nextWrapperURL, parentURLs, options, (err, wrappedResponse) =>
                     errorAlreadyRaised = false
                     if err?

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -432,6 +432,8 @@ describe 'VASTParser', ->
 
             it 'should have retrieved Ad attributes', =>
                 _response.ads[1].id.should.eql "ad_id_0002"
+
+            it 'should have ignored the wrapper\'s sequence', =>
                 should.equal _response.ads[1].sequence, null
 
             it 'should have retrieved Ad sub-elements values', =>
@@ -514,6 +516,23 @@ describe 'VASTParser', ->
                         'http://example.com/wrapperA-linear-clicktracking3'
                     ]
 
+        describe '#For the wrapper-1 ad', ->
+            @response = null
+            @templateFilterCalls = []
+
+            before (done) =>
+                VASTParser.addURLTemplateFilter (url) =>
+                    @templateFilterCalls.push url
+                    return url
+                VASTParser.parse urlfor('wrapper-1.xml'), (@response) =>
+                    done()
+
+            it 'should have called 2 times URLtemplateFilter ', =>
+                @templateFilterCalls.should.have.length 2
+                @templateFilterCalls.should.eql [urlfor('wrapper-1.xml'), urlfor('sample-1.xml')]
+
+            it 'should have carried sequence over from wrapper', =>
+                @response.ads[0].sequence.should.eql "1"
 
         describe '#VAST', ->
             @response = null


### PR DESCRIPTION
If there is a wrapper tag in an ad with a sequence, this pr will set that sequence on the ad found from the wrapper request. Right now it is coming back as null