### PR TITLE
Return Promise for client and parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ import { VASTClient } from 'vast-client'
 
 const vastClient = new VASTClient();
 
-vastClient.get('https://www.exampleVast.com/vast.xml', (err, res) => {
-  // Do something with the parsed VAST response
+vastClient.get('https://www.examplevast.com/vast.xml')
+  .then(res => {
+    // Do something with the parsed VAST response
+  })
+  .catch(err => {
+    // Deal with the error
+  })
 });
 ```
 In addition to fetching and parsing a VAST resource, **VASTClient** provides options to filter a sequence of calls based on count and time of execution, together with the possibility to track URLs using **VASTTracker**.
@@ -42,7 +47,12 @@ import { VASTParser } from 'vast-client'
 const vastParser = new VASTParser();
 
 vastParser.parseVAST(vastXml, (err, res) => {
-  // Do something with the parsed VAST XML
+  .then(res => {
+    // Do something with the parsed VAST response
+  })
+  .catch(err => {
+    // Deal with the error
+  })
 });
 ```
 

--- a/docs/api/2.0-migration.md
+++ b/docs/api/2.0-migration.md
@@ -88,16 +88,27 @@ client.vastParser.addURLTemplateFilter( vastUrl => url.replace('[DOMAIN]', 'mywe
 client.get(vastUrl, options, cb);
 ```
 
-## Error first callbacks everywhere
-Every callback function now follows the error first standard. Therefore the function to pass as callback parameter should have the following signature:
+## Promises over callback
+Every callback function has been replaced with an es6 `Promise`.
 ```Javascript
-function(err, res) {
+// before
+vastClient.get('https://www.examplevast.com/vast.xml', (err, res) => {
   if (err) {
     // Deal with the error
   }
 
   // Deal with the result
 }
+
+// after
+vastClient.get('https://www.examplevast.com/vast.xml')
+  .then(res => {
+    // Do something with the parsed VAST response
+  })
+  .catch(err => {
+    // Deal with the error
+  })
+});
 ```
 
 ## Changes in Client API
@@ -108,7 +119,7 @@ As mentioned in the first section, now you can use the client only through an in
 The constructor is now the preferred way to set the class properties. Direct access to properties should be avoided when possible.
 
 ### Breaking changes in method signatures
-No breaking changes in `VASTClient` methods.
+ * `get(url, [options,] cb)` becomes `get(url, options)`
 
 ## Changes in Parser API
 
@@ -118,8 +129,8 @@ As mentioned in the first section, you can now only use the parser through an in
 ### Breaking changes in methods signatures
 These changes are mostly due to the semantic meaning of methods names.
 
- * `parse(url, [options,] cb)` becomes `getAndParseVAST(url, options, cb)`
- * `load(vastXml, [options,] cb)` becomes `parseVAST(vastXml, options, cb)`
+ * `parse(url, [options,] cb)` becomes `getAndParseVAST(url, options)`
+ * `load(vastXml, [options,] cb)` becomes `parseVAST(vastXml, options)`
 
 `1.x` - Fetch and parse a VAST or simply parse a VAST:
 ```Javascript
@@ -139,12 +150,14 @@ DMVAST.parser.load(vastXml, options, cb);
 // To fetch and parse a VAST
 const vastUrl = 'http://example.dailymotion.com/vast.xml';
 
-vastParser.getAndParseVAST(vastUrl, options, cb);
+// A Promise is returned
+vastParser.getAndParseVAST(vastUrl, options);
 
 // To parse an already fetched VAST xml
 const vastXml = (new window.DOMParser()).parseFromString(xmlStr, "text/xml");
 
-vastParser.parseVAST(vastXml, options, cb);
+// A Promise is returned
+vastParser.parseVAST(vastXml, options);
 ```
 
 ### Breaking changes in events

--- a/docs/api/vast-client.md
+++ b/docs/api/vast-client.md
@@ -48,11 +48,11 @@ Example: if set to `3`, the first 3 VAST requests will not be executed.
 vastClient.cappingFreeLunch = 2;
 
 // Those following vastClient.get calls won't be done
-vastClient.get(VASTUrl, cb);
-vastClient.get(VASTUrl, cb);
+vastClient.get(VASTUrl);
+vastClient.get(VASTUrl);
 
 // VASTUrl will be called
-vastClient.get(VASTUrl, cb);
+vastClient.get(VASTUrl);
 ```
 
 #### cappingMinimumTimeInterval: Number
@@ -65,13 +65,13 @@ Example: if set to `2000`, any call which will be requested less than 2 seconds 
 vastClient.cappingMinimumTimeInterval = 5 * 60 * 1000;
 
 // The call is made
-vastClient.get(VASTUrl, cb);
+vastClient.get(VASTUrl);
 
 // 2 minutes later: The call is ignored
-vastClient.get(VASTUrl, cb);
+vastClient.get(VASTUrl);
 
 // d minutes later: The call is made
-vastClient.get(VASTUrl, cb);
+vastClient.get(VASTUrl);
 ```
 
 #### storage: Storage
@@ -79,10 +79,10 @@ Instance of a class which implements the `Storage` interface. Should be set up o
 
 ## Public Methods 💚 <a name="methods"></a>
 
-### get(url, [options,] cb)
+### get(url, [options,] cb): Promise
 Gets a parsed VAST document for the given url, applying the skipping rules defined (`cappingFreeLunch` and `cappingMinimumTimeInterval`).
 
-When done executes the callback with either an Error or the fully parsed [`VASTResponse`](../../src/vast_response.js).
+Returns a `Promise` which either resolves with the fully parsed [`VASTResponse`](../../src/vast_response.js) or rejects with an `Error`.
 
 #### Parameters
  * **`url: String`** - The url to use to fecth the VAST document
@@ -91,15 +91,18 @@ When done executes the callback with either an Error or the fully parsed [`VASTR
     * `withCredentials: Boolean` - A boolean to enable the withCredentials options for the XHR and FLASH URLHandlers (default `false`)
     * `wrapperLimit: Number` - A number of Wrapper responses that can be received with no InLine response (default `0`)
     * `urlHandler: URLHandler` - Custom urlhandler to be used instead of the default ones [`urlhandlers`](../../src/urlhandlers)
- * **`cb: function`** - Error first callback which will be called once the parsing is done
 
 #### Example
 ```Javascript
 const vastClient = new VASTClient();
 
-vastClient.get('http://example.dailymotion.com/vast.xml', (err, res) => {
-  // Do something with the parsed VASTResponse
-});
+vastClient.get('http://example.dailymotion.com/vast.xml')
+  .then(res => {
+    // Do something with the parsed VAST response
+  })
+  .catch(err => {
+    // Deal with the error
+  })
 
 // With the options optional parameter
 const options = {
@@ -107,9 +110,13 @@ const options = {
   wrapperLimit: 7
 };
 
-vastClient.get('http://example.dailymotion.com/vast.xml', options, (err, res) => {
-  // Do something with the parsed VASTResponse
-});
+vastClient.get('http://example.dailymotion.com/vast.xml', options)
+  .then(res => {
+    // Do something with the parsed VAST response
+  })
+  .catch(err => {
+    // Deal with the error
+  })
 ```
 
 #### getParser()

--- a/docs/api/vast-parser.md
+++ b/docs/api/vast-parser.md
@@ -135,7 +135,7 @@ Tracks the error provided in the errorCode parameter and emits a `VAST-error` ev
  * **`data: Object`** - One (or more) Object containing additional data
 
 ### fetchVAST(url, options)
-Fetches a VAST document for the given url. Returns a `Promise` which resolves or rejects according to the result of the request.
+Fetches a VAST document for the given url. Returns a `Promise` which resolves with the fetched xml or rejects with an error, according to the result of the request.
 
 #### Parameters
  * **`url: String`** - The url to request the VAST document
@@ -149,7 +149,8 @@ Fetches a VAST document for the given url. Returns a `Promise` which resolves or
  * **`VAST-resolving`**
 
 ### getAndParseVAST(url, options, cb)<a name="getandparse"></a>
-Fetches and parses a VAST for the given url. Executes the callback with either an error or the fully parsed `VASTResponse`.
+Fetches and parses a VAST for the given url.
+Returns a `Promise` which either resolves with the fully parsed [`VASTResponse`](../../src/vast_response.js) or rejects with an `Error`.
 
 #### Parameters
  * **`url: String`** - The url to request the VAST document
@@ -158,7 +159,6 @@ Fetches and parses a VAST for the given url. Executes the callback with either a
     * `withCredentials: Boolean` - A boolean to enable the withCredentials options for the XHR and FLASH URLHandlers (default `false`)
     * `wrapperLimit: Number` - A number of Wrapper responses that can be received with no InLine response (default `0`)
     * `urlHandler: URLHandler` - Custom urlhandler to be used instead of the default ones [`urlhandlers`](../../src/urlhandlers)
- * **`cb: function`** - Error first callback which will be called once the parsing is done
 
 #### Events emitted
  * **`VAST-resolved`**
@@ -166,9 +166,13 @@ Fetches and parses a VAST for the given url. Executes the callback with either a
 
 #### Example
 ```Javascript
-vastParser.getAndParseVAST('http://example.dailymotion.com/vast.xml', (err, res) => {
-  // Do something with the parsed VASTResponse
-});
+vastParser.getAndParseVAST('http://example.dailymotion.com/vast.xml')
+  .then(res => {
+    // Do something with the parsed VAST response
+  })
+  .catch(err => {
+    // Deal with the error
+  })
 
 // With some options
 const options = {
@@ -176,13 +180,18 @@ const options = {
   withCredentials: true,
   wrapperLimit: 7
 }
-vastParser.getAndParseVAST('http://example.dailymotion.com/vast.xml', options, (err, res) => {
-  // Do something with the parsed VASTResponse
-});
+vastParser.getAndParseVAST('http://example.dailymotion.com/vast.xml', options)
+  .then(res => {
+    // Do something with the parsed VAST response
+  })
+  .catch(err => {
+    // Deal with the error
+  })
 ```
 
 ### parseVAST(vastXml, options, cb)<a name="parse"></a>
-Parses the given xml Object into a `VASTResponse`. Executes the callback with either an error or the fully parsed `VASTResponse`.
+Parses the given xml Object into a `VASTResponse`.
+Returns a `Promise` which either resolves with the fully parsed [`VASTResponse`](../../src/vast_response.js) or rejects with an `Error`.
 
 #### Parameters
  * **`vastXml: Object`** - An object representing an xml document
@@ -191,7 +200,6 @@ Parses the given xml Object into a `VASTResponse`. Executes the callback with ei
     * `withCredentials: Boolean` - A boolean to enable the withCredentials options for the XHR and FLASH URLHandlers (default `false`)
     * `wrapperLimit: Number` - A number of Wrapper responses that can be received with no InLine response (default `0`)
     * `urlHandler: URLHandler` - Custom urlhandler to be used instead of the default ones [`urlhandlers`](../../src/urlhandlers)
- * **`cb: function`** - Error first callback which will be called once the parsing is done
 
 #### Events emitted
  * **`VAST-resolved`**
@@ -201,9 +209,13 @@ Parses the given xml Object into a `VASTResponse`. Executes the callback with ei
 ```Javascript
 const vastXml = (new window.DOMParser()).parseFromString(xmlStr, "text/xml");
 
-vastParser.parseVAST(vastXml, (err, res) => {
-  // Do something with the parsed VASTResponse
-});
+vastParser.parseVAST(vastXml)
+  .then(res => {
+    // Do something with the parsed VAST response
+  })
+  .catch(err => {
+    // Deal with the error
+  })
 ```
 
 ## Private Methods :warning:<a name="private-methods"></a>

--- a/test/vast_parser.js
+++ b/test/vast_parser.js
@@ -31,14 +31,13 @@ describe('VASTParser', function() {
         this.templateFilterCalls.push(url);
         return url;
       });
-      vastParser.getAndParseVAST(
-        urlfor('wrapper-notracking.xml'),
-        (err, response) => {
+      vastParser
+        .getAndParseVAST(urlfor('wrapper-notracking.xml'))
+        .then(response => {
           this.response = response;
           _response = this.response;
           done();
-        }
-      );
+        });
     });
 
     after(() => {
@@ -793,13 +792,12 @@ describe('VASTParser', function() {
           this.templateFilterCalls.push(url);
           return url;
         });
-        vastParser.getAndParseVAST(
-          urlfor('wrapper-sequence.xml'),
-          (err, response) => {
+        vastParser
+          .getAndParseVAST(urlfor('wrapper-sequence.xml'))
+          .then(response => {
             this.response = response;
             done();
-          }
-        );
+          });
       });
 
       it('should have called 2 times URLtemplateFilter ', () => {
@@ -819,7 +817,7 @@ describe('VASTParser', function() {
       this.response = null;
 
       before(done => {
-        vastParser.getAndParseVAST(urlfor('vpaid.xml'), (err, response) => {
+        vastParser.getAndParseVAST(urlfor('vpaid.xml')).then(response => {
           this.response = response;
           done();
         });
@@ -840,13 +838,12 @@ describe('VASTParser', function() {
       this.response = null;
 
       before(done => {
-        vastParser.getAndParseVAST(
-          urlfor('wrapper-ad-pod.xml'),
-          (err, response) => {
+        vastParser
+          .getAndParseVAST(urlfor('wrapper-ad-pod.xml'))
+          .then(response => {
             this.response = response;
             done();
-          }
-        );
+          });
       });
 
       it('should have parsed 2 ads', () => {
@@ -895,7 +892,7 @@ describe('VASTParser', function() {
           }
         }
 
-        vastParser.parseVAST(xml, (err, response) => {
+        vastParser.parseVAST(xml).then(response => {
           this.response = response;
           done();
         });
@@ -948,30 +945,28 @@ describe('VASTParser', function() {
     });
 
     describe('#No-Ad', function() {
-      it('emits a VAST-error & track', done =>
-        vastParser.getAndParseVAST(
-          urlfor('empty-no-ad.xml'),
-          (err, response) => {
-            // Response doesn't have any ads
-            response.ads.should.eql([]);
-            // Error has been triggered
-            dataTriggered.length.should.eql(1);
-            dataTriggered[0].ERRORCODE.should.eql(303);
-            dataTriggered[0].extensions.should.eql([]);
-            // Tracking has been done
-            trackCalls.length.should.eql(1);
-            trackCalls[0].templates.should.eql([
-              'http://example.com/empty-no-ad'
-            ]);
-            trackCalls[0].variables.should.eql({ ERRORCODE: 303 });
-            done();
-          }
-        ));
+      it('emits a VAST-error & track', done => {
+        vastParser.getAndParseVAST(urlfor('empty-no-ad.xml')).then(response => {
+          // Response doesn't have any ads
+          response.ads.should.eql([]);
+          // Error has been triggered
+          dataTriggered.length.should.eql(1);
+          dataTriggered[0].ERRORCODE.should.eql(303);
+          dataTriggered[0].extensions.should.eql([]);
+          // Tracking has been done
+          trackCalls.length.should.eql(1);
+          trackCalls[0].templates.should.eql([
+            'http://example.com/empty-no-ad'
+          ]);
+          trackCalls[0].variables.should.eql({ ERRORCODE: 303 });
+          done();
+        });
+      });
 
-      it('when wrapped, emits a VAST-error & track', done =>
-        vastParser.getAndParseVAST(
-          urlfor('wrapper-empty.xml'),
-          (err, response) => {
+      it('when wrapped, emits a VAST-error & track', done => {
+        vastParser
+          .getAndParseVAST(urlfor('wrapper-empty.xml'))
+          .then(response => {
             // Response doesn't have any ads
             response.ads.should.eql([]);
             // Error has been triggered
@@ -991,15 +986,15 @@ describe('VASTParser', function() {
             ]);
             trackCalls[0].variables.should.eql({ ERRORCODE: 303 });
             done();
-          }
-        ));
+          });
+      });
     });
 
     describe('#Ad with no creatives', function() {
-      it('emits a VAST-error & track', done =>
-        vastParser.getAndParseVAST(
-          urlfor('empty-no-creative.xml'),
-          (err, response) => {
+      it('emits a VAST-error & track', done => {
+        vastParser
+          .getAndParseVAST(urlfor('empty-no-creative.xml'))
+          .then(response => {
             // Response doesn't have any ads
             response.ads.should.eql([]);
             // Error has been triggered
@@ -1018,13 +1013,13 @@ describe('VASTParser', function() {
             ]);
             trackCalls[0].variables.should.eql({ ERRORCODE: 303 });
             done();
-          }
-        ));
+          });
+      });
 
-      it('when wrapped, emits a VAST-error & track', done =>
-        vastParser.getAndParseVAST(
-          urlfor('wrapper-empty-no-creative.xml'),
-          (err, response) => {
+      it('when wrapped, emits a VAST-error & track', done => {
+        vastParser
+          .getAndParseVAST(urlfor('wrapper-empty-no-creative.xml'))
+          .then(response => {
             // Response doesn't have any ads
             response.ads.should.eql([]);
             // Error has been triggered
@@ -1050,33 +1045,27 @@ describe('VASTParser', function() {
             ]);
             trackCalls[0].variables.should.eql({ ERRORCODE: 303 });
             done();
-          }
-        ));
+          });
+      });
     });
 
     describe('#Invalid XML file (parsing error)', function() {
-      it('returns an error', done =>
-        vastParser.getAndParseVAST(
-          urlfor('invalid-xmlfile.xml'),
-          (err, response) => {
-            // No response returned
-            should.not.exist(response);
-            // Error returned
-            err.should.be
-              .instanceof(Error)
-              .and.have.property('message', 'Invalid VAST XMLDocument');
-            done();
-          }
-        ));
+      it('returns an error', done => {
+        vastParser.getAndParseVAST(urlfor('invalid-xmlfile.xml')).catch(err => {
+          // Error returned
+          err.should.be
+            .instanceof(Error)
+            .and.have.property('message', 'Invalid VAST XMLDocument');
+          done();
+        });
+      });
 
-      it('when wrapped, emits a VAST-error & track', done =>
-        vastParser.getAndParseVAST(
-          urlfor('wrapper-invalid-xmlfile.xml'),
-          (err, response) => {
+      it('when wrapped, emits a VAST-error & track', done => {
+        vastParser
+          .getAndParseVAST(urlfor('wrapper-invalid-xmlfile.xml'))
+          .then(response => {
             // Response doesn't have any ads
             response.ads.should.eql([]);
-            // No error returned
-            should.not.exist(err);
             // Error has been triggered
             dataTriggered.length.should.eql(1);
             dataTriggered[0].ERRORCODE.should.eql(301);
@@ -1093,20 +1082,17 @@ describe('VASTParser', function() {
             ]);
             trackCalls[0].variables.should.eql({ ERRORCODE: 301 });
             done();
-          }
-        ));
+          });
+      });
     });
 
-    describe('#Wrapper limit reached', () =>
-      it('emits a VAST-error & track', done =>
-        vastParser.getAndParseVAST(
-          urlfor('wrapper-a.xml'),
-          { wrapperLimit: 1 },
-          (err, response) => {
+    describe('#Wrapper limit reached', () => {
+      it('emits a VAST-error & track', done => {
+        vastParser
+          .getAndParseVAST(urlfor('wrapper-a.xml'), { wrapperLimit: 1 })
+          .then(response => {
             // Response doesn't have any ads
             response.ads.should.eql([]);
-            // No error returned
-            should.not.exist(err);
             // Error has been triggered
             dataTriggered.length.should.eql(1);
             dataTriggered[0].ERRORCODE.should.eql(302);
@@ -1123,8 +1109,9 @@ describe('VASTParser', function() {
             ]);
             trackCalls[0].variables.should.eql({ ERRORCODE: 302 });
             done();
-          }
-        )));
+          });
+      });
+    });
   });
 
   describe('#legacy', function() {
@@ -1132,10 +1119,10 @@ describe('VASTParser', function() {
       vastParser.removeAllListeners();
     });
 
-    it('correctly loads a wrapped ad, even with the VASTAdTagURL-Tag', done =>
-      vastParser.getAndParseVAST(
-        urlfor('wrapper-legacy.xml'),
-        (err, response) => {
+    it('correctly loads a wrapped ad, even with the VASTAdTagURL-Tag', done => {
+      vastParser
+        .getAndParseVAST(urlfor('wrapper-legacy.xml'))
+        .then(response => {
           it('should have found 1 ad', () => {
             response.ads.should.have.length(1);
           });
@@ -1155,7 +1142,7 @@ describe('VASTParser', function() {
           });
 
           done();
-        }
-      ));
+        });
+    });
   });
 });

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -35,7 +35,7 @@ describe('VASTTracker', function() {
         return url;
       });
 
-      vastParser.getAndParseVAST(urlfor('wrapper-a.xml'), (err, response) => {
+      vastParser.getAndParseVAST(urlfor('wrapper-a.xml')).then(response => {
         this.response = response;
         done();
       });


### PR DESCRIPTION
After converting the library to pure es6 Javascript, we want to improve our public API by dropping node-like callbacks in favour of es6 Promises.

- [x]  Update VASTClient methods
- [x]  Update VASTParser methods
- [x]  Fix tests
- [x]  Update documentation