### PR TITLE
Parsing broken on no ad VAST

### DIFF
--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -337,7 +337,7 @@ export class VASTParser extends EventEmitter {
    * @param {Object} options - An options Object containing resolving parameters
    * @return {Promise}
    */
-  resolveAds(ads, { wrapperDepth, originalUrl }) {
+  resolveAds(ads = [], { wrapperDepth, originalUrl }) {
     return new Promise((resolve, reject) => {
       const resolveWrappersPromises = [];
 

--- a/test/vast_client.js
+++ b/test/vast_client.js
@@ -142,6 +142,16 @@ describe('VASTClient', () => {
         resolveAll: false
       };
 
+      it('should handle correctly a no ad response', done => {
+        vastClient.get(urlfor('empty-no-ad.xml'), getOptions).then(response => {
+          vastResponse = response;
+          should.notEqual(response, null);
+          // Response doesn't have any ads
+          response.ads.should.eql([]);
+          done();
+        });
+      });
+
       it('should be successfull', done => {
         vastClient.get(vastUrl, getOptions).then(response => {
           vastResponse = response;


### PR DESCRIPTION
When `options.resolveAll` is set to `false` parsing breaks on no ad VAST response.

We need to add a default value for the `ads` parameter when we try to resolve wrappers on a no ad VAST.