### PR TITLE
Make node engine version more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "8.9.4"
+    "node": ">=8.9.4"
   },
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Let's allow any node version major than `8.9.4`

See https://github.com/dailymotion/vast-client-js/issues/233
And https://github.com/dailymotion/vast-client-js/pull/234