### PR TITLE
[parser] Fix wrapper timeout/URI unavailable causing the parsing to fail

### DIFF
--- a/test/vast_parser.js
+++ b/test/vast_parser.js
@@ -1114,6 +1114,33 @@ describe('VASTParser', function() {
       });
     });
 
+    describe('#Wrapper URL unavailable/timeout', () => {
+      it('emits a VAST-error & track', done => {
+        vastParser
+          .getAndParseVAST(urlfor('wrapper-unavailable-url.xml'), options)
+          .then(response => {
+            // Response doesn't have any ads
+            response.ads.should.eql([]);
+            // Error has been triggered
+            dataTriggered.length.should.eql(1);
+            dataTriggered[0].ERRORCODE.should.eql(301);
+            dataTriggered[0].extensions[0].children[0].name.should.eql(
+              'paramWrapperInvalidXmlfile'
+            );
+            dataTriggered[0].extensions[0].children[0].value.should.eql(
+              'valueWrapperInvalidXmlfile'
+            );
+            // Tracking has been done
+            trackCalls.length.should.eql(1);
+            trackCalls[0].templates.should.eql([
+              'http://example.com/wrapper-invalid-xmlfile_wrapper-error'
+            ]);
+            trackCalls[0].variables.should.eql({ ERRORCODE: 301 });
+            done();
+          });
+      });
+    });
+
     describe('#Wrapper limit reached', () => {
       it('emits a VAST-error & track', done => {
         vastParser

--- a/test/vastfiles/wrapper-unavailable-url.xml
+++ b/test/vastfiles/wrapper-unavailable-url.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<VAST version="2.0">
+  <Ad>
+    <Wrapper>
+      <AdSystem>VAST</AdSystem>
+      <VASTAdTagURI>invalid-url</VASTAdTagURI>
+      <Error>http://example.com/wrapper-invalid-xmlfile_wrapper-error</Error>
+      <Impression>http://example.com/wrapper-invalid-xmlfile_impression</Impression>
+      <Creatives>
+        <Creative>
+          <CompanionAds>
+            <Companion id="urn:a2:287461:103" width="0" height="0">
+              <CompanionClickThrough><![CDATA[http://example.com/wrapper-invalid-xmlfile_companion_click-thru]]></CompanionClickThrough>
+              <CompanionClickTracking><![CDATA[http://example.com/wrapper-invalid-xmlfile_companion_click-tracking]]></CompanionClickTracking>
+              <AdParameters><![CDATA[campaign_id=10446]]></AdParameters>
+            </Companion>
+          </CompanionAds>
+        </Creative>
+        <Creative>
+          <Linear>
+            <TrackingEvents>
+              <Tracking event="start"><![CDATA[http://example.com/wrapper-invalid-xmlfile_linear_start]]></Tracking>
+              <Tracking event="complete"><![CDATA[http://example.com/wrapper-invalid-xmlfile_linear_complete]]></Tracking>
+            </TrackingEvents>
+            <VideoClicks>
+              <ClickTracking><![CDATA[http://example.com/wrapper-invalid-xmlfile_linear_clicktracking]]></ClickTracking>
+            </VideoClicks>
+          </Linear>
+        </Creative>
+      </Creatives>
+      <Extensions>
+        <Extension>
+            <paramWrapperInvalidXmlfile><![CDATA[valueWrapperInvalidXmlfile]]></paramWrapperInvalidXmlfile>
+        </Extension>
+      </Extensions>
+    </Wrapper>
+  </Ad>
+</VAST>


### PR DESCRIPTION
If the first VAST URI in a wrapper timed-out/is unavailable the entire parsing fails
because the catch() that handles this starts in the second wrapper chain, not the first.