### PR TITLE
Clickthrough fallback

### DIFF
--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -306,9 +306,10 @@ export class VASTTracker extends EventEmitter {
    * It calls the tracking URLs and emits a 'clickthrough' event with the resolved
    * clickthrough URL when done.
    *
+   * @param {String} [fallbackClickThroughURL=null] - an optional clickThroughURL template that could be used as a fallback
    * @emits VASTTracker#clickthrough
    */
-  click() {
+  click(fallbackClickThroughURL = null) {
     if (
       this.clickTrackingURLTemplates &&
       this.clickTrackingURLTemplates.length
@@ -316,12 +317,16 @@ export class VASTTracker extends EventEmitter {
       this.trackURLs(this.clickTrackingURLTemplates);
     }
 
-    if (this.clickThroughURLTemplate) {
+    // Use the provided fallbackClickThroughURL as a fallback
+    const clickThroughURLTemplate =
+      this.clickThroughURLTemplate || fallbackClickThroughURL;
+
+    if (clickThroughURLTemplate) {
       const variables = this.linear
         ? { CONTENTPLAYHEAD: this.progressFormatted() }
         : {};
       const clickThroughURL = util.resolveURLTemplates(
-        [this.clickThroughURLTemplate],
+        [clickThroughURLTemplate],
         variables
       )[0];
 

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -5,6 +5,7 @@ import { VASTParser } from '../src/parser/vast_parser';
 import { VASTTracker } from '../src/vast_tracker';
 import { nodeURLHandler } from '../src/urlhandlers/node_url_handler';
 import { util } from '../src/util/util';
+import { CreativeLinear } from '../src/creative/creative_linear';
 
 const now = new Date();
 const vastParser = new VASTParser();
@@ -487,7 +488,7 @@ describe('VASTTracker', function() {
           ]);
         });
 
-        it('should have sent clickthrough event withy clickThrough url', () => {
+        it('should have sent clickthrough event with clickThrough url', () => {
           _eventsSent[1].event.should.eql('clickthrough');
           _eventsSent[1].args.should.eql([
             'http://example.com/companion1-clickthrough'
@@ -529,12 +530,88 @@ describe('VASTTracker', function() {
           ]);
         });
 
-        it('should have sent clickthrough event withy clickThrough url', () => {
+        it('should have sent clickthrough event with clickThrough url', () => {
           _eventsSent[1].event.should.eql('clickthrough');
           _eventsSent[1].args.should.eql([
             'http://example.com/nonlinear-clickthrough'
           ]);
         });
+      });
+    });
+  });
+
+  describe('#clickthroughs', () => {
+    const fallbackClickThroughURL = 'http://example.com/fallback-clickthrough',
+      clickThroughURL = 'http://example.com/clickthrough';
+
+    describe('#VAST clickThrough with no fallback provided', () => {
+      const eventsSent = [];
+      before(() => {
+        // Init tracker
+        const creative = new CreativeLinear();
+        creative.videoClickThroughURLTemplate = clickThroughURL;
+        const tracker = new VASTTracker(vastClient, {}, creative);
+        // Mock emit
+        tracker.emit = (event, ...args) => {
+          eventsSent.push({ event, args });
+        };
+        tracker.click();
+      });
+      it('should have sent clickthrough event with VAST clickThrough url', () => {
+        eventsSent[0].event.should.eql('clickthrough');
+        eventsSent[0].args.should.eql([clickThroughURL]);
+      });
+    });
+
+    describe('#VAST clickThrough with fallback provided', () => {
+      const eventsSent = [];
+      before(() => {
+        // Init tracker
+        const creative = new CreativeLinear();
+        creative.videoClickThroughURLTemplate = clickThroughURL;
+        const tracker = new VASTTracker(vastClient, {}, creative);
+        // Mock emit
+        tracker.emit = (event, ...args) => {
+          eventsSent.push({ event, args });
+        };
+        tracker.click(fallbackClickThroughURL);
+      });
+      it('should have sent clickthrough event with VAST clickThrough url', () => {
+        eventsSent[0].event.should.eql('clickthrough');
+        eventsSent[0].args.should.eql([clickThroughURL]);
+      });
+    });
+
+    describe('#empty VAST clickThrough with no fallback provided', () => {
+      const eventsSent = [];
+      before(() => {
+        // Init tracker
+        const tracker = new VASTTracker(vastClient, {}, {});
+        // Mock emit
+        tracker.emit = (event, ...args) => {
+          eventsSent.push({ event, args });
+        };
+        tracker.click();
+      });
+      it("shouldn't have sent any event", () => {
+        eventsSent.should.have.length(0);
+      });
+    });
+
+    describe('#empty VAST clickThrough with fallback provided', () => {
+      const eventsSent = [];
+      before(() => {
+        // Init tracker
+        const tracker = new VASTTracker(vastClient, {}, {});
+        // Mock emit
+        tracker.emit = (event, ...args) => {
+          eventsSent.push({ event, args });
+        };
+        tracker.click(fallbackClickThroughURL);
+      });
+      it('should have sent fallback clickthrough', () => {
+        eventsSent[0].event.should.eql('clickthrough');
+        eventsSent[0].args.should.eql([fallbackClickThroughURL]);
       });
     });
   });


### PR DESCRIPTION
These commits are related to the following issue : https://github.com/dailymotion/vast-client-js/issues/150

We choosed to use the provided url as a fallback to avoid having the clickthrough from the vast being overrided.