### PR TITLE
Source code as module entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=8.9.4"
   },
   "main": "dist/vast-client-node.min.js",
-  "module": "dist/vast-client-module.min.js",
+  "module": "src/index.js",
   "browser": {
     "dist/vast-client.min.js": "dist/vast-client.min.js"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Elia Maino <eliamaino@gmail.com>"
   ],
   "version": "2.2.1",
-  "description": "Javascript VAST Client",
+  "description": "JavaScript VAST Client",
   "keywords": [
     "vast",
     "ad",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,15 +73,6 @@ const nodeConfig = {
   onwarn
 };
 
-const moduleConfig = {
-  input: 'src/index.js',
-  output: {
-    format: 'es',
-    file: 'dist/vast-client-module.min.js'
-  },
-  plugins: [builtins(), uglify()]
-};
-
 export default [
   // Browser-friendly UMD build [package.json "browser"]
   browserConfig,
@@ -89,8 +80,5 @@ export default [
 
   // CommonJS build for Node usage [package.json "main"]
   nodeConfig,
-  minify(nodeConfig),
-
-  // Minified version with es6 module exports [package.json "module"]
-  moduleConfig
+  minify(nodeConfig)
 ];


### PR DESCRIPTION
### Description

Provide the source code as `module` entry in `package.json`. 

The `module`, if available, is used by webpack to bundle the library together with the rest of a project codebase. 

Currently we provide `dist/vast-client-module.min.js` as `module` entry, in order to always apply some optimizations provided by rollup. This may (we're not 100% sure) get us winning some KB in the final bundle size, but requires us to bundle the library when we want to test a branch different than master.

After some testing I realized the supposed gain in bundle size is not that big, therefore I opted to go back to the standard way and directly provide the source code of the lib as the `module` entry.

### Issue

Plus this will unlock https://github.com/dailymotion/vast-client-js/issues/249

### Type
- [ ] Breaking change
- [ ] Enhancement
- [ ] Fix
- [ ] Documentation
- [X] Tooling
