### PR TITLE
Fix options.urlHandler assertion

### DIFF
--- a/docs/api/vast-client.md
+++ b/docs/api/vast-client.md
@@ -93,6 +93,7 @@ By default the fully parsed `VASTResponse` contains all the Ads contained in the
     * `withCredentials: Boolean` - A boolean to enable the withCredentials options for the XHR and FLASH URLHandlers (default `false`)
     * `wrapperLimit: Number` - A number of Wrapper responses that can be received with no InLine response (default `0`)
     * `urlHandler: URLHandler` - Custom urlhandler to be used instead of the default ones [`urlhandlers`](../../src/urlhandlers)
+    * `urlhandler: URLHandler` - Fulfills the same purpose as `urlHandler`, which is the preferred parameter to use
     * `resolveAll: Boolean` - Allows you to parse all the ads contained in the VAST or to parse them ad by ad or adPod by adPod (default `true`)
 
 #### Example

--- a/docs/api/vast-parser.md
+++ b/docs/api/vast-parser.md
@@ -184,6 +184,7 @@ Returns a `Promise` which either resolves with the fully parsed [`VASTResponse`]
     * `withCredentials: Boolean` - A boolean to enable the withCredentials options for the XHR and FLASH URLHandlers (default `false`)
     * `wrapperLimit: Number` - A number of Wrapper responses that can be received with no InLine response (default `0`)
     * `urlHandler: URLHandler` - Custom urlhandler to be used instead of the default ones [`urlhandlers`](../../src/urlhandlers)
+    * `urlhandler: URLHandler` - Fulfills the same purpose as `urlHandler`, which is the preferred parameter to use
 
 #### Events emitted
  * **`VAST-resolved`**
@@ -225,6 +226,7 @@ Returns a `Promise` which either resolves with the fully parsed `VASTResponse` o
     * `withCredentials: Boolean` - A boolean to enable the withCredentials options for the XHR and FLASH URLHandlers (default `false`)
     * `wrapperLimit: Number` - A number of Wrapper responses that can be received with no InLine response (default `0`)
     * `urlHandler: URLHandler` - Custom urlhandler to be used instead of the default ones [`urlhandlers`](../../src/urlhandlers)
+    * `urlhandler: URLHandler` - Fulfills the same purpose as `urlHandler`, which is the preferred parameter to use
 
 #### Events emitted
  * **`VAST-resolved`**

--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -141,7 +141,7 @@ export class VASTParser extends EventEmitter {
       withCredentials: options.withCredentials
     };
 
-    this.urlHandler = options.urlhandler || urlHandler;
+    this.urlHandler = options.urlHandler || options.urlhandler || urlHandler;
   }
 
   /**


### PR DESCRIPTION
### Description

According to the documentation, you can pass a custom URL handler to the `options` parameter via `options.urlHandler`.

The code block responsible for applying this custom `urlhandler` is not doing the assertion correctly, leading to only `options.urlhandler` with lower-case `h` working.

### Issue

Untracked issue.

### Type
- [ ] Breaking change
- [ ] Enhancement
- [x] Fix
- [x] Documentation
- [ ] Tooling
