### PR TITLE
Skip tracking makes any further tracking not working

### DIFF
--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -347,7 +347,6 @@ export class VASTTracker extends EventEmitter {
    */
   skip() {
     this.track('skip');
-    this.trackingEvents = [];
   }
 
   /**


### PR DESCRIPTION
### Description

The issue would cause any subsequent tracking to not trigger tracking URL after calling tracking for the Skip event
A legacy piece of code would cause this error.

### Issue

github.com/dailymotion/vast-client-js/issues/281

### Type
- [x] Fix
