### PR TITLE
Support Linear ads events and Player Operation events for VAST 4.1

### DIFF
--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -53,9 +53,12 @@ Here is the list of events emitted by the class:
  * **`exitFullscreen`** - Emitted when calling `setFullscreen(fullscreen)` and changing the fullscreen state from true to false
  * **`firstQuartile`** - Only for linear ads with a duration. Emitted when the adunit has reached 25% of its duration
  * **`fullscreen`** - Emitted when calling `setFullscreen(fullscreen)` and changing the fullscreen state from false to true
+ * **`loaded`** - Only for linear ad. Emitted when calling `load()`.
  * **`midpoint`** - Only for linear ads with a duration. Emitted when the adunit has reached 50% of its duration
  * **`mute`** - Emitted when calling `setMuted(muted)` and changing the mute state from false to true
  * **`pause`** - Emitted when calling `setPaused(paused)` and changing the pause state from false to true
+ * **`playerExpand`** - Emitted when calling `setExpand(true)` is called. This event replaces the fullscreen event in VAST 4.1
+ * **`playerCollapse`** - Emitted when calling `setExpand(false)` is called. This event replaces the exitFullscreen event in VAST 4.1
  * **`progress-[0-100]%`** - Only for linear ads with a duration. Emitted on every `setProgress(duration)` calls, where [0-100] is the adunit percentage completion
  * **`progress-[currentTime]`** - Only for linear ads with a duration. Emitted on every `setProgress(duration)` calls, where [currentTime] is the adunit current time
  * **`resume`** - Emitted when calling `setPaused(paused)` and changing the pause state from true to false
@@ -83,6 +86,24 @@ const MEDIAFILE_PLAYBACK_ERROR = '405';
 // Bind error listener to the player
 player.on('error', () => {
   vastTracker.errorWithCode(MEDIAFILE_PLAYBACK_ERROR);
+});
+```
+
+### load()
+Must be called when the player considers that it has loaded and buffered the creative’s media and assets either fully or to the extent that it is ready to play the media.
+
+#### Events emitted
+ * **`loaded`**
+
+#### Example
+```Javascript
+// Bind ended listener to the player
+player.on('loaded', () => {
+  vastTracker.load();
+});
+
+vastTracker.on('loaded', () => {
+  // loaded tracking URLs have been called
 });
 ```
 
@@ -173,14 +194,17 @@ Sets the duration of the ad and updates the quartiles based on that.
  * **`duration: Number`** - The duration of the ad
 
 ### setExpand(expanded)
-Updates the expand state and calls the expand/collapse tracking URLs.
+Updates the expand state and calls the expand/collapse as well as playerExpand/playerCollapse for VAST 4.1. tracking URLs.
 
 #### Parameters
  * **`expanded: Boolean`** - Indicates if the video is expanded or not
 
 #### Events emitted
  * **`expand`**
+ * **`playerExpand`**
  * **`collapse`**
+ * **`playerCollapse`**
+
 
 #### Example
 ```Javascript

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "rollup -c",
     "lint": "eslint .",
     "precommit": "eslint . --max-warnings 0 && pretty-quick --staged",
-    "test": "mocha --compilers js:@babel/register --reporter spec test/*.js && jest",
+    "test": "mocha && jest",
     "jest": "jest"
   },
   "devDependencies": {

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -273,7 +273,9 @@ export class VASTTracker extends EventEmitter {
    *
    * @param {Boolean} expanded - Indicates if the video is expanded or not.
    * @emits VASTTracker#expand
+   * @emits VASTTracker#playerExpand
    * @emits VASTTracker#collapse
+   * @emits VASTTracker#playerCollapse
    */
   setExpand(expanded) {
     if (this.expanded !== expanded) {
@@ -358,9 +360,9 @@ export class VASTTracker extends EventEmitter {
   /**
    * Must be called then loaded and buffered the creative’s media and assets either fully
    * or to the extent that it is ready to play the media
-   * Calls the load tracking URLs.
+   * Calls the loaded tracking URLs.
    *
-   * @emits VASTTracker#complete
+   * @emits VASTTracker#loaded
    */
   load() {
     this.track('loaded');

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -278,6 +278,7 @@ export class VASTTracker extends EventEmitter {
   setExpand(expanded) {
     if (this.expanded !== expanded) {
       this.track(expanded ? 'expand' : 'collapse');
+      this.track(expanded ? 'playerExpand' : 'playerCollapse');
     }
     this.expanded = expanded;
   }
@@ -352,6 +353,17 @@ export class VASTTracker extends EventEmitter {
    */
   skip() {
     this.track('skip');
+  }
+
+  /**
+   * Must be called then loaded and buffered the creative’s media and assets either fully
+   * or to the extent that it is ready to play the media
+   * Calls the load tracking URLs.
+   *
+   * @emits VASTTracker#complete
+   */
+  load() {
+    this.track('loaded');
   }
 
   /**

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--require @babel/register
+--reporter spec test/*.js

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -236,8 +236,14 @@ describe('VASTTracker', function() {
         before(done => {
           _eventsSent = [];
           this.Tracker.trackingEvents['expand'] = 'http://example.com/expand';
+          this.Tracker.trackingEvents[
+            'playerExpand'
+          ] = this.Tracker.trackingEvents['expand'];
           this.Tracker.trackingEvents['collapse'] =
             'http://example.com/collapse';
+          this.Tracker.trackingEvents[
+            'playerCollapse'
+          ] = this.Tracker.trackingEvents['collapse'];
           this.Tracker.setExpand(true);
           done();
         });
@@ -247,7 +253,7 @@ describe('VASTTracker', function() {
         });
 
         it('should send expand event', () => {
-          _eventsSent.should.eql(['expand']);
+          _eventsSent.should.eql(['expand', 'playerExpand']);
         });
 
         it('should be in collapsed mode', () => {
@@ -257,7 +263,7 @@ describe('VASTTracker', function() {
         });
 
         it('should send collapse event', () => {
-          _eventsSent.should.eql(['collapse']);
+          _eventsSent.should.eql(['collapse', 'playerCollapse']);
         });
 
         it('should send no event', () => {
@@ -417,6 +423,15 @@ describe('VASTTracker', function() {
 
         it('should have sent skip event', () => {
           _eventsSent.should.eql(['skip']);
+        });
+      });
+
+      describe('#load', () => {
+        it('should have sent load event', () => {
+          _eventsSent = [];
+          this.Tracker.trackingEvents['loaded'] = ['http://example.com/loaded'];
+          this.Tracker.load();
+          _eventsSent.should.eql(['loaded', ['http://example.com/loaded']]);
         });
       });
 


### PR DESCRIPTION
Support Linear ads events and Player Operation events for VAST 4.1
moved mocha configs to separate file to be able run any isolated test from IDE

### Description

VAST 4.1 contains additional tracking events: *playerExpand/playerCollapse* which eventually replaces the *fullscreen/exitFullscreen* events and *loaded* which track then everything loaded for playing.

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [x] Documentation
- [ ] Tooling
