### PR TITLE
Support Ad Verification for VAST 4.1

### DIFF
--- a/docs/api/class-reference.md
+++ b/docs/api/class-reference.md
@@ -24,6 +24,7 @@ This class represents a single parsed Ad
 - `impressionURLTemplates: Array<String>`
 - `creatives: Array<Creative>` [go to class](#creative)
 - `extensions: Array<AdExtension>` [go to class](#ad-extension)
+- `adVerifications: Array<AdVerification>` [go to class](#ad-verification)
 
 ## Creative<a name="creative"></a>
 
@@ -139,3 +140,10 @@ This class represents a generic Creative. It's used as a parent class for more s
 - `attributes: Object`
 - `children: Array<AdExtension>`
 - `isEmpty(): Boolean` Returns true when none of these attributes have a value
+
+## AdVerification<a name="ad-verification"></a>
+- `apiFramework: String|null` The name of the API framework used to execute the AdVerification code
+- `browserOptional: Boolean` If *true*, this resource is optimized and able to execute in an environment without DOM and other browser built-ins (e.g. iOS' JavaScriptCore).
+- `parameters: String|null` Metadata about the current impression
+- `resource: String|null` URI to the JavaScript file used to collect verification data
+- `vendor: String|null` An identifier for the verification vendor

--- a/src/ad.js
+++ b/src/ad.js
@@ -12,5 +12,6 @@ export class Ad {
     this.impressionURLTemplates = [];
     this.creatives = [];
     this.extensions = [];
+    this.adVerifications = [];
   }
 }

--- a/src/ad_verification.js
+++ b/src/ad_verification.js
@@ -1,0 +1,9 @@
+export class AdVerification {
+  constructor() {
+    this.resource = null;
+    this.vendor = null;
+    this.browserOptional = false;
+    this.apiFramework = null;
+    this.parameters = null;
+  }
+}

--- a/src/parser/ad_parser.js
+++ b/src/parser/ad_parser.js
@@ -1,5 +1,6 @@
 import { Ad } from '../ad';
 import { AdExtension } from '../ad_extension';
+import { AdVerification } from '../ad_verification';
 import { parseCreativeCompanion } from './creative_companion_parser';
 import { parseCreativeLinear } from './creative_linear_parser';
 import { parseCreativeNonLinear } from './creative_non_linear_parser';
@@ -110,6 +111,12 @@ function parseInLine(inLineElement) {
       case 'Extensions':
         ad.extensions = _parseExtensions(
           parserUtils.childrenByName(node, 'Extension')
+        );
+        break;
+
+      case 'AdVerifications':
+        ad.adVerifications = _parseAdVerifications(
+          parserUtils.childrenByName(node, 'Verification')
         );
         break;
 
@@ -305,6 +312,44 @@ function _parseExtension(extNode) {
   // Only return not empty objects to not pollute extentions
   return ext.isEmpty() ? null : ext;
 }
+
+/**
+ * Parses the AdVerifications Element.
+ * @param  {Array} verifications - The array of verifications to parse.
+ * @return {Array<AdVerification>}
+ */
+
+export function _parseAdVerifications(verifications) {
+  const ver = [];
+
+  verifications.forEach(verificationNode => {
+    const verification = new AdVerification();
+    const childNodes = verificationNode.childNodes;
+
+    parserUtils.assignAttributes(
+        verificationNode.attributes,
+        verification
+    );
+    for (const nodeKey in childNodes) {
+      const node = childNodes[nodeKey];
+
+      switch (node.nodeName) {
+        case 'JavaScriptResource':
+          verification.resource = parserUtils.parseNodeText(node);
+          parserUtils.assignAttributes(node.attributes, verification);
+          break;
+        case 'VerificationParameters':
+          verification.parameters = parserUtils.parseNodeText(node);
+          break;
+      }
+    }
+
+    ver.push(verification);
+  });
+
+  return ver;
+}
+
 
 /**
  * Parses the creative adId Attribute.

--- a/src/parser/parser_utils.js
+++ b/src/parser/parser_utils.js
@@ -188,6 +188,32 @@ function splitVAST(ads) {
 }
 
 /**
+ * Parses the attributes and assign them to object
+ * @param  {Object} attributes attribute
+ * @param  {Object} verificationObject with properties which can be assigned
+ */
+function assignAttributes(attributes, verificationObject) {
+  if (attributes) {
+    for (const attrKey in attributes) {
+      const attribute = attributes[attrKey];
+
+      if (
+          attribute.nodeName &&
+          attribute.nodeValue &&
+          verificationObject.hasOwnProperty(attribute.nodeName)
+      ) {
+        let value = attribute.nodeValue;
+
+        if (typeof verificationObject[attribute.nodeName] === 'boolean') {
+          value = parseBoolean(value);
+        }
+        verificationObject[attribute.nodeName] = value;
+      }
+    }
+  }
+}
+
+/**
  * Merges the data between an unwrapped ad and his wrapper.
  * @param  {Ad} unwrappedAd - The 'unwrapped' Ad.
  * @param  {Ad} wrapper - The wrapper Ad.
@@ -290,5 +316,6 @@ export const parserUtils = {
   parseAttributes,
   parseDuration,
   splitVAST,
+  assignAttributes,
   mergeWrapperAdData
 };

--- a/test/vast_parser.js
+++ b/test/vast_parser.js
@@ -201,6 +201,20 @@ describe('VASTParser', function() {
         ad1.extensions.should.have.length(4);
       });
 
+      it('should have 2 AdVerification URLs VAST 4.1', () => {
+        ad1.adVerifications.should.have.length(2);
+      });
+
+      it('validate second adVerification', () => {
+        ad1.adVerifications[1].resource.should.eql('http://example.com/omid2');
+        ad1.adVerifications[1].vendor.should.eql('company2.com-omid');
+        ad1.adVerifications[1].browserOptional.should.eql(false);
+        ad1.adVerifications[1].apiFramework.should.eql('omid');
+        ad1.adVerifications[1].parameters.should.eql(
+            'test-verification-parameter'
+        );
+      });
+
       it('should not have trackingEvents property', () => {
         should.equal(ad1.trackingEvents, undefined);
       });

--- a/test/vastfiles/sample.xml
+++ b/test/vastfiles/sample.xml
@@ -12,6 +12,21 @@
       <Impression><![CDATA[http://example.com/impression1_asset:[ASSETURI]_[CACHEBUSTING]]]></Impression>
       <Impression><![CDATA[http://example.com/impression2_[random]]]></Impression>
       <Impression><![CDATA[http://example.com/impression3_[RANDOM]]]></Impression>
+      <AdVerifications>
+        <Verification vendor="company.com-omid">
+          <JavaScriptResource apiFramework="omid" browserOptional="true">
+            <![CDATA[http://example.com/omid1]]>
+          </JavaScriptResource>
+        </Verification>
+        <Verification vendor="company2.com-omid">
+          <JavaScriptResource apiFramework="omid" browserOptional="false">
+            <![CDATA[http://example.com/omid2]]>
+          </JavaScriptResource>
+          <VerificationParameters>
+            <![CDATA[test-verification-parameter]]>
+          </VerificationParameters>
+        </Verification>
+      </AdVerifications>
       <Creatives>
         <Creative id="id130984" adId="adId345690" sequence="1" >
           <Linear>


### PR DESCRIPTION
VAST 4 offers a designated space (<AdVerifications>) for inserting ad verification APIs, enabling a more streamlined process for executing files strictly intended for ad verification. Open Measurement (OM) is expected to be used for this purpose.

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [x] Documentation
- [ ] Tooling
