### PR TITLE
Support Mezzanine for VAST 4.1

### DIFF
--- a/docs/api/class-reference.md
+++ b/docs/api/class-reference.md
@@ -41,6 +41,7 @@ This class represents a generic Creative. It's used as a parent class for more s
 - `duration: Number`
 - `skipDelay: Number|null`
 - `mediaFiles: Array<MediaFile>` [go to class](#mediafile)
+- `mezzanine: Object<Mezzanine>` [go to class](#mezzanine)
 - `videoClickThroughURLTemplate: String|null`
 - `videoClickTrackingURLTemplates: Array<String>`
 - `videoCustomClickURLTemplates: Array<String>`
@@ -75,6 +76,18 @@ This class represents a generic Creative. It's used as a parent class for more s
 - `apiFramework: String|null`
 - `scalable: Boolean|null`
 - `maintainAspectRatio: Boolean|null`
+
+## Mezzanine<a name="mezzanine"></a>
+
+- `delivery: String` Either "progressive" for progressive download protocols (such as HTTP) or "streaming" for streaming protocols
+- `type: String` MIME type for the file container. Popular MIME types include, but are not limited to "video/mp4" for MP4, "audio/mpeg" and "audio/aac" for audio ads
+- `width: Number`
+- `height: Number`
+- `codec: String|null` The codec used to encode the file which can take values as specified by RFC 4281: http://tools.ietf.org/html/rfc4281
+- `id: String|null`
+- `fileSize: Number|null`
+- `mediaType: String|null` Type of media file (3D / 360 / etc). Optional. Default value = 2D
+- `fileURL: String|null`
 
 ## NonLinearAd<a name="non-linear-ad"></a>
 

--- a/src/creative/creative_linear.js
+++ b/src/creative/creative_linear.js
@@ -8,6 +8,7 @@ export class CreativeLinear extends Creative {
     this.duration = 0;
     this.skipDelay = null;
     this.mediaFiles = [];
+    this.mezzanine = null;
     this.videoClickThroughURLTemplate = null;
     this.videoClickTrackingURLTemplates = [];
     this.videoCustomClickURLTemplates = [];

--- a/src/mezzanine.js
+++ b/src/mezzanine.js
@@ -1,0 +1,13 @@
+export class Mezzanine {
+  constructor() {
+    this.id = null;
+    this.fileURL = null;
+    this.delivery = null;
+    this.codec = null;
+    this.type = null;
+    this.width = 0;
+    this.height = 0;
+    this.fileSize = 0;
+    this.mediaType = '2D';
+  }
+}

--- a/src/parser/creative_linear_parser.js
+++ b/src/parser/creative_linear_parser.js
@@ -1,6 +1,7 @@
 import { CreativeLinear } from '../creative/creative_linear';
 import { Icon } from '../icon';
 import { MediaFile } from '../media_file';
+import { Mezzanine } from '../mezzanine';
 import { parserUtils } from './parser_utils';
 
 /**
@@ -158,6 +159,37 @@ export function parseCreativeLinear(creativeElement, creativeAttributes) {
 
           creative.mediaFiles.push(mediaFile);
         });
+
+      const mezzanineElement = parserUtils.childByName(
+        mediaFilesElement,
+        'Mezzanine'
+      );
+      const requiredAttributes = getRequiredAttributes(mezzanineElement, [
+        'delivery',
+        'type',
+        'width',
+        'height'
+      ]);
+
+      if (requiredAttributes) {
+        const mezzanine = new Mezzanine();
+
+        mezzanine.id = mezzanineElement.getAttribute('id');
+        mezzanine.fileURL = parserUtils.parseNodeText(mezzanineElement);
+        mezzanine.delivery = requiredAttributes.delivery;
+        mezzanine.codec = mezzanineElement.getAttribute('codec');
+        mezzanine.type = requiredAttributes.type;
+        mezzanine.width = parseInt(requiredAttributes.width, 10);
+        mezzanine.height = parseInt(requiredAttributes.height, 10);
+        mezzanine.fileSize = parseInt(
+          mezzanineElement.getAttribute('fileSize'),
+          10
+        );
+        mezzanine.mediaType =
+          mezzanineElement.getAttribute('mediaType') || '2D';
+
+        creative.mezzanine = mezzanine;
+      }
     });
 
   const iconsElement = parserUtils.childByName(creativeElement, 'Icons');
@@ -250,4 +282,25 @@ function parseYPosition(yPosition) {
   }
 
   return parseInt(yPosition || 0);
+}
+
+/**
+ * Getting required attributes from element
+ * @param  {Object} element - DOM element
+ * @param  {Array} attributes - list of attributes
+ * @return {Object|null} null if a least one element not present
+ */
+function getRequiredAttributes(element, attributes) {
+  const values = {};
+  let error = false;
+
+  attributes.forEach(name => {
+    if (!element || !element.getAttribute(name)) {
+      error = true;
+    } else {
+      values[name] = element.getAttribute(name);
+    }
+  });
+
+  return error ? null : values;
 }

--- a/test/vast_parser.js
+++ b/test/vast_parser.js
@@ -293,6 +293,20 @@ describe('VASTParser', function() {
           );
         });
 
+        it('should have parsed mezzanine file attributes', () => {
+          linear.mezzanine.delivery.should.equal('progressive');
+          linear.mezzanine.type.should.equal('video/mp4');
+          linear.mezzanine.width.should.equal(1080);
+          linear.mezzanine.height.should.equal(720);
+          linear.mezzanine.codec.should.equal('h264');
+          linear.mezzanine.id.should.equal('mezzanine-id-165468451');
+          linear.mezzanine.fileSize.should.equal(700);
+          linear.mezzanine.mediaType.should.equal('2D');
+          linear.mezzanine.fileURL.should.equal(
+            'http://example.com/linear-mezzanine.mp4'
+          );
+        });
+
         it('should have 1 URL for clickthrough', () => {
           linear.videoClickThroughURLTemplate.should.eql(
             'http://example.com/linear-clickthrough'

--- a/test/vastfiles/sample.xml
+++ b/test/vastfiles/sample.xml
@@ -50,6 +50,7 @@
             <MediaFiles>
               <MediaFile delivery="progressive" type="video/mp4" bitrate="849" width="512" height="288" scalable="true"><![CDATA[http://example.com/linear-asset.mp4]]></MediaFile>
               <MediaFile apiFramework="VPAID" type="application/javascript" width="512" height="288" delivery="progressive"><![CDATA[parser.js?adData=http%3A%2F%2Fad.com%2F%3Fcb%3D%5Btime%5D]]></MediaFile>
+              <Mezzanine id="mezzanine-id-165468451" type="video/mp4" width="1080" height="720" delivery="progressive" codec="h264" fileSize="700"><![CDATA[http://example.com/linear-mezzanine.mp4]]></Mezzanine>
             </MediaFiles>
             <Icons>
               <Icon program="ad1" width="60" height="20" xPosition="left" yPosition="bottom" duration="00:01:30.000" offset="00:00:15.000" apiFramework="VPAID">


### PR DESCRIPTION
To support advertising across video platforms that include long-form content and high-resolution screens, VAST 4 features include support for the raw, high-quality mezzanine file. The mezzanine file is very large and cannot be used for ad display, but ad-stitching services and other ad vendor use it to generate files at appropriate quality levels for the environment in which they play.

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [x] Documentation
- [ ] Tooling
