### PR TITLE
Update Object.assign usages to avoid mutating initial argument

### DIFF
--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -80,7 +80,7 @@ export class VASTParser extends EventEmitter {
   trackVastError(urlTemplates, errorCode, ...data) {
     this.emit(
       'VAST-error',
-      Object.assign(DEFAULT_EVENT_DATA, errorCode, ...data)
+      Object.assign({}, DEFAULT_EVENT_DATA, errorCode, ...data)
     );
     util.track(urlTemplates, errorCode);
   }

--- a/src/vast_client.js
+++ b/src/vast_client.js
@@ -92,7 +92,7 @@ export class VASTClient {
    */
   get(url, options = {}) {
     const now = Date.now();
-    options = Object.assign(this.defaultOptions, options);
+    options = Object.assign({}, this.defaultOptions, options);
 
     // By default the client resolves only the first Ad or AdPod
     if (!options.hasOwnProperty('resolveAll')) {


### PR DESCRIPTION
### Description

This PR fixes up two usages of `Object.assign` to avoid mutating objects that act as default key/value maps.

Donating a `{}` to each call was simpler than refactoring to spread. The spread was also rejected by lint. I went for the path of least change to address the linked issue.

### Issue

Issue Link #309

### Type

To me this is a fix and a breaking change. The behavior of public interface methods changed but using them in their previous state may have been unexpected enough to ignore the delta. I just checked both and assume you all will resolve as you see fit.

Thanks again. :)

- [x] Breaking change
- [ ] Enhancement
- [x] Fix
- [ ] Documentation
- [ ] Tooling
