### PR TITLE
Add missing tracker to docs

### DIFF
--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -51,6 +51,7 @@ vastTracker.on('exitFullscreen', () => {
 |`complete`|Only for linear ads with a duration. Emitted after `complete()` has been called.|`{ trackingURLTemplates: Array<String> }`|
 |`clickthrough`|Emitted when calling `click()` if there is at least one `<clickThroughURLTemplate>` element. A URL will be passed as a data|`String`|
 |`close`|Only for non-linear ads, emitted when `close()` is called|`{ trackingURLTemplates: Array<String> }`|
+|`closeLinear`|Only for linear ads, emitted when `close()` is called|`{ trackingURLTemplates: Array<String> }`|
 |`collapse`|Emitted when calling `setExpand(expanded)` and changing the expand state from true to false|`{ trackingURLTemplates: Array<String> }`|
 |`creativeView`|Emitted when `trackImpression()` is called.|`{ trackingURLTemplates: Array<String> }`|
 |`exitFullscreen`|Emitted when calling `setFullscreen(fullscreen)` and changing the fullscreen state from true to false|`{ trackingURLTemplates: Array<String> }`|

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -339,7 +339,7 @@ export class VASTTracker extends EventEmitter {
 
   /**
    * Must be called when the player or the window is closed during the ad.
-   * Calls the `closeLinear` (in VAST 3.0) and `close` tracking URLs.
+   * Calls the `closeLinear` (in VAST 3.0 and 4.1) and `close` tracking URLs.
    *
    * @emits VASTTracker#closeLinear
    * @emits VASTTracker#close


### PR DESCRIPTION
### Description

`closeLinear` was missing in vast-tracker docs.

### Type
- [ ] Breaking change
- [ ] Enhancement
- [ ] Fix
- [x] Documentation
- [ ] Tooling
