### PR TITLE
Add tool to compare bundle sizes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 dist/
+dist_old/
 !.eslintrc.js
 rollup.config.js
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/*
 npm-debug.log
+dist_old

--- a/bundleSize.js
+++ b/bundleSize.js
@@ -18,11 +18,11 @@ Object.entries(oldValues).forEach(([name, size]) => {
   const newSize = newValues[name];
   const delta = newSize - size;
   const sizeColorFg = delta <= 0 ? '\x1b[32m' : '\x1b[31m';
-  const reset = '\x1b[0m';
+  const resetColorFg = '\x1b[0m';
   const nameColorFg = '\x1b[36m';
   // eslint-disable-next-line no-console
   console.log(
-    `${nameColorFg}%s${reset}%s${sizeColorFg}%s${reset}`,
+    `${nameColorFg}%s${resetColorFg}%s${sizeColorFg}%s${resetColorFg}`,
     `${name}:`,
     ` ${size} B -> ${newSize} B `,
     `(${delta >= 0 ? '+' : ''}${delta} B)`

--- a/bundleSize.js
+++ b/bundleSize.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+const newDistPath = './dist';
+const oldDistPath = './dist_old';
+
+const getFileSizes = folderPath => {
+  return fs.readdirSync(folderPath).reduce((res, fileName) => {
+    res[fileName] = fs.readFileSync(path.join(folderPath, fileName)).byteLength;
+    return res;
+  }, {});
+};
+
+const oldValues = getFileSizes(oldDistPath);
+const newValues = getFileSizes(newDistPath);
+
+Object.entries(oldValues).forEach(([name, size]) => {
+  const newSize = newValues[name];
+  const delta = newSize - size;
+  const sizeColorFg = delta <= 0 ? '\x1b[32m' : '\x1b[31m';
+  const reset = '\x1b[0m';
+  const nameColorFg = '\x1b[36m';
+  // eslint-disable-next-line no-console
+  console.log(
+    `${nameColorFg}%s${reset}%s${sizeColorFg}%s${reset}`,
+    `${name}:`,
+    ` ${size} B -> ${newSize} B `,
+    `(${delta >= 0 ? '+' : ''}${delta} B)`
+  );
+});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "main": "dist/vast-client-node.min.js",
   "browser": "dist/vast-client.min.js",
   "scripts": {
+    "prebuild": "rm -rf dist_old && mkdir dist_old && cp -a dist/. dist_old/",
     "build": "rollup -c",
+    "postbuild": "node bundleSize.js",
     "lint": "eslint .",
     "precommit": "eslint . --max-warnings 0 && pretty-quick --staged",
     "test": "mocha && jest",


### PR DESCRIPTION
### Description

It is possible now to compare local bundle size vs last build.

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [ ] Documentation
- [x] Tooling

<img width="814" alt="Screenshot 2019-10-04 at 10 11 07" src="https://user-images.githubusercontent.com/9026911/66191753-51e22e00-e68f-11e9-960b-f52310771a31.png">
