### PR TITLE
Implement missing VAST 4.1 trackers 

### DIFF
--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -382,3 +382,160 @@ vastTracker.on('creativeView', () => {
   // impression tracking URLs have been called
 });
 ```
+
+### notUsed()
+Must be called if the ad was not and will not be played (e.g. it was prefetched for a particular
+ad break but was not chosen for playback). This allows ad servers to reuse an ad earlier
+than otherwise would be possible due to budget/frequency capping. This is a terminal event;
+no other tracking events should be sent when this is used. Player support is
+optional and if implemented is provided on a best effort basis as it is not technically
+possible to fire this event for every unused ad (e.g. when the player itself is terminated
+before playback). This is a terminal event; no other tracking events should be sent when this is used.
+
+Calls the notUsed tracking URLs.
+
+#### Events emitted
+ * **`notUsed`**
+
+#### Example
+```Javascript
+vastTracker.on('notUsed', () => {
+  // notUsed tracking URLs have been called
+});
+
+// Called notUsed if the ad was not and will not be played.
+vastTracker.notUsed();
+
+```
+
+### otherAdInteraction()
+An optional metric that can capture all other user interactions
+under one metric such as hover-overs, or custom clicks. It should NOT replace
+clickthrough events or other existing events like mute, unmute, pause, etc.
+
+Calls the otherAdInteraction tracking URLs.
+
+#### Events emitted
+ * **`otherAdInteraction`**
+
+#### Example
+```Javascript
+// Bind mouseover listener to the player
+player.addEventListener('mouseover', () => vastTracker.otherAdInteraction() );
+
+vastTracker.on('otherAdInteraction', () => {
+  // otherAdInteraction tracking URLs have been called
+});
+```
+
+### acceptInvitation()
+The user clicked or otherwise activated a control used to pause
+streaming content, which either expands the ad within the player’s viewable area or
+“takes-over” the streaming content area by launching an additional portion of the ad. An ad in video format ad is usually played upon acceptance, but other forms of
+media such as games, animation, tutorials, social media, or other engaging media
+are also used.
+
+Calls the acceptInvitation tracking URLs.
+
+#### Events emitted
+ * **`acceptInvitation`**
+
+#### Example
+```Javascript
+// Bind click listener to the invitation button
+invitationButton.on('click', () => {
+  vastTracker.acceptInvitation();
+});
+
+vastTracker.on('acceptInvitation', () => {
+  // acceptInvitation tracking URLs have been called
+});
+```
+
+### adExpand()
+The user activated a control to expand the creative.
+
+Calls the adExpand tracking URLs.
+
+#### Events emitted
+ * **`adExpand`**
+
+#### Example
+```Javascript
+// Bind click listener to the ad expand button
+adExpandButton.on('click', () => {
+  vastTracker.adExpand();
+});
+
+vastTracker.on('adExpand', () => {
+  // adExpand tracking URLs have been called
+});
+```
+
+### adCollapse()
+The user activated a control to reduce the creative to its original
+dimensions.
+
+Calls the adCollapse tracking URLs.
+
+#### Events emitted
+ * **`adCollapse`**
+
+#### Example
+```Javascript
+// Bind click listener to the ad collapse button
+adCollapseButton.on('click', () => {
+  vastTracker.adCollapse();
+});
+
+vastTracker.on('adCollapse', () => {
+  // adCollapse tracking URLs have been called
+});
+```
+
+### minimize()
+The user clicked or otherwise activated a control used to minimize the ad
+to a size smaller than a collapsed ad but without fully dispatching the ad from the
+player environment. Unlike a collapsed ad that is big enough to display it’s message,
+the minimized ad is only big enough to offer a control that enables the user to
+redisplay the ad if desired.
+
+Calls the minimize tracking URLs.
+
+#### Events emitted
+ * **`minimize`**
+
+#### Example
+```Javascript
+// Bind click listener to the ad collapse button
+minimizeButton.on('click', () => {
+  vastTracker.minimize();
+});
+
+vastTracker.on('minimize', () => {
+  // minimize tracking URLs have been called
+});
+```
+
+### overlayViewDuration()
+The time that the initial ad is displayed. This time is based on
+the time between the impression and either the completed length of display based
+on the agreement between transactional parties or a close, minimize, or accept
+invitation event.
+
+Calls the overlayViewDuration tracking URLs.
+
+#### Events emitted
+ * **`overlayViewDuration`**
+
+#### Example
+```Javascript
+// Bind click listener to the ad collapse button
+minimizeButton.on('click', () => {
+  vastTracker.minimize();
+});
+
+vastTracker.on('overlayViewDuration', () => {
+  // overlayViewDuration tracking URLs have been called
+});
+```

--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -73,6 +73,13 @@ vastTracker.on('exitFullscreen', () => {
 |`start`|Only for linear ads with a duration. Emitted on the 1st non-null `setProgress(duration)` call|`{ trackingURLTemplates: Array<String> }`|
 |`thirdQuartile`|Only for linear ads with a duration. Emitted when the adunit has reached 75% of its duration|`{ trackingURLTemplates: Array<String> }`|
 |`unmute`|Emitted when calling `setMuted(muted)` and changing the mute state from true to false|`{ trackingURLTemplates: Array<String> }`|
+|`notUsed`|Emitted when calling `notUsed()`.This is a terminal event; no other tracking events are sent when this is used|`{ trackingURLTemplates: Array<String> }`|
+|`otherAdInteraction`|Emitted when calling `otherAdInteraction()`|`{ trackingURLTemplates: Array<String> }`|
+|`acceptInvitation`|Emitted when calling `acceptInvitation()`|`{ trackingURLTemplates: Array<String> }`|
+|`adExpand`|Emitted when calling `adExpand()`|`{ trackingURLTemplates: Array<String> }`|
+|`adCollapse`|Emitted when calling `adCollapse()`|`{ trackingURLTemplates: Array<String> }`|
+|`minimize`|Emitted when calling `minimize()`|`{ trackingURLTemplates: Array<String> }`|
+|`overlayViewDuration`|Emitted when calling `overlayViewDuration()`|`{ trackingURLTemplates: Array<String> }`|
 
 ## Public Methods 💚 <a name="methods"></a>
 

--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -386,8 +386,7 @@ vastTracker.on('creativeView', () => {
 ### notUsed()
 Must be called if the ad was not and will not be played (e.g. it was prefetched for a particular
 ad break but was not chosen for playback). This allows ad servers to reuse an ad earlier
-than otherwise would be possible due to budget/frequency capping. This is a terminal event;
-no other tracking events should be sent when this is used. Player support is
+than otherwise would be possible due to budget/frequency capping. Player support is
 optional and if implemented is provided on a best effort basis as it is not technically
 possible to fire this event for every unused ad (e.g. when the player itself is terminated
 before playback). This is a terminal event; no other tracking events should be sent when this is used.
@@ -530,12 +529,9 @@ Calls the overlayViewDuration tracking URLs.
 
 #### Example
 ```Javascript
-// Bind click listener to the ad collapse button
-minimizeButton.on('click', () => {
-  vastTracker.minimize();
-});
-
 vastTracker.on('overlayViewDuration', () => {
   // overlayViewDuration tracking URLs have been called
 });
+// Call the overlayViewDuration event
+vastTracker.overlayViewDuration();
 ```

--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -46,6 +46,7 @@ export const inlineTrackers = `
               <Tracking event="adCollapse"><![CDATA[http://example.com/linear-adCollapse]]></Tracking>
               <Tracking event="minimize"><![CDATA[http://example.com/linear-minimize]]></Tracking>
               <Tracking event="overlayViewDuration"><![CDATA[http://example.com/linear-overlayViewDuration]]></Tracking>
+              <Tracking event="notUsed"><![CDATA[http://example.com/linear-notUsed]]></Tracking>
             </TrackingEvents>
             <VideoClicks>
               <ClickTracking id='video-click-1'><![CDATA[http://example.com/linear-clicktracking1_ts:[TIMESTAMP]]]></ClickTracking>

--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -1,0 +1,92 @@
+export const inlineTrackers = `
+<VAST version="2.1">
+  <Ad id="ad_id_0001" sequence="1">
+    <InLine>
+      <AdSystem version="2.0"><![CDATA[AdServer]]></AdSystem>
+      <AdTitle><![CDATA[Ad title]]></AdTitle>
+      <Advertiser id='advertiser-desc'><![CDATA[Advertiser name]]></Advertiser>
+      <Description><![CDATA[Description text]]></Description>
+      <Pricing model="CPM" currency="USD"><![CDATA[1.09]]></Pricing>
+      <Survey><![CDATA[http://example.com/survey]]></Survey>
+      <Error><![CDATA[http://example.com/error_[ERRORCODE]]]></Error>
+      <Impression id="sample-impression1"><![CDATA[http://example.com/impression1_asset:[ASSETURI]_[CACHEBUSTING]]]></Impression>
+      <Impression id="sample-impression2"><![CDATA[http://example.com/impression2_[random]]]></Impression>
+      <Impression id="sample-impression3"><![CDATA[http://example.com/impression3_[RANDOM]]]></Impression>
+      <AdVerifications>
+        <Verification vendor="company.com-omid">
+          <JavaScriptResource apiFramework="omid" browserOptional="true">
+            <![CDATA[http://example.com/omid1]]>
+          </JavaScriptResource>
+        </Verification>
+        <Verification vendor="company2.com-omid">
+          <JavaScriptResource apiFramework="omid" browserOptional="false">
+            <![CDATA[http://example.com/omid2]]>
+          </JavaScriptResource>
+          <VerificationParameters>
+            <![CDATA[test-verification-parameter]]>
+          </VerificationParameters>
+        </Verification>
+      </AdVerifications>
+      <Creatives>
+        <Creative id="id130984" adId="adId345690" sequence="1">
+          <Linear>
+            <Duration>00:01:30.123</Duration>
+            <TrackingEvents>
+              <Tracking event="midpoint"><![CDATA[http://example.com/linear-midpoint]]></Tracking>
+              <Tracking event="complete"><![CDATA[http://example.com/linear-complete]]></Tracking>
+              <Tracking event="start"><![CDATA[http://example.com/linear-start]]></Tracking>
+              <Tracking event="firstQuartile"><![CDATA[http://example.com/linear-firstQuartile]]></Tracking>
+              <Tracking event="close"><![CDATA[http://example.com/linear-close]]></Tracking>
+              <Tracking event="thirdQuartile"><![CDATA[http://example.com/linear-thirdQuartile]]></Tracking>
+              <Tracking event="progress" offset="00:00:30.000"><![CDATA[http://example.com/linear-progress-30sec]]></Tracking>
+              <Tracking event="progress" offset="60%"><![CDATA[http://example.com/linear-progress-60%]]></Tracking>
+              <Tracking event="otherAdInteraction"><![CDATA[http://example.com/linear-otherAdInteraction]]></Tracking>
+              <Tracking event="acceptInvitation"><![CDATA[http://example.com/linear-acceptInvitation]]></Tracking>
+              <Tracking event="adExpand"><![CDATA[http://example.com/linear-adExpand]]></Tracking>
+              <Tracking event="adCollapse"><![CDATA[http://example.com/linear-adCollapse]]></Tracking>
+              <Tracking event="minimize"><![CDATA[http://example.com/linear-minimize]]></Tracking>
+              <Tracking event="overlayViewDuration"><![CDATA[http://example.com/linear-overlayViewDuration]]></Tracking>
+            </TrackingEvents>
+            <VideoClicks>
+              <ClickTracking id='video-click-1'><![CDATA[http://example.com/linear-clicktracking1_ts:[TIMESTAMP]]]></ClickTracking>
+              <ClickTracking id='video-click-2'><![CDATA[http://example.com/linear-clicktracking2]]></ClickTracking>
+              <ClickThrough id='click-through'><![CDATA[http://example.com/linear-clickthrough]]></ClickThrough>
+              <CustomClick id='custom-click-1'><![CDATA[http://example.com/linear-customclick]]></CustomClick>
+            </VideoClicks>
+            <MediaFiles>
+              <MediaFile delivery="progressive" type="video/mp4" bitrate="849" width="512" height="288" scalable="true"><![CDATA[http://example.com/linear-asset.mp4]]></MediaFile>
+              <MediaFile apiFramework="VPAID" type="application/javascript" width="512" height="288" delivery="progressive"><![CDATA[parser.js?adData=http%3A%2F%2Fad.com%2F%3Fcb%3D%5Btime%5D]]></MediaFile>
+              <Mezzanine id="mezzanine-id-165468451" type="video/mp4" width="1080" height="720" delivery="progressive" codec="h264" fileSize="700"><![CDATA[http://example.com/linear-mezzanine.mp4]]></Mezzanine>
+            </MediaFiles>
+            <Icons>
+              <Icon program="ad1" width="60" height="20" xPosition="left" yPosition="bottom" duration="00:01:30.000" offset="00:00:15.000" apiFramework="VPAID" pxratio="2">
+                <StaticResource creativeType="image/gif"><![CDATA[http://example.com/linear-icon.gif]]></StaticResource>
+                <IconViewTracking><![CDATA[http://example.com/linear-viewtracking]]></IconViewTracking>
+                <IconClicks>
+                  <IconClickThrough><![CDATA[http://example.com/linear-clickthrough]]></IconClickThrough>
+                  <IconClickTracking id='icon-click-1'><![CDATA[http://example.com/linear-clicktracking1]]></IconClickTracking>
+                  <IconClickTracking id='icon-click-2'><![CDATA[http://example.com/linear-clicktracking2]]></IconClickTracking>
+                </IconClicks>
+              </Icon>
+            </Icons>
+          </Linear>
+        </Creative>
+      </Creatives>
+      <Extensions>
+        <Extension type="Pricing">
+          <Price model="CPM" currency="USD" source="someone">
+            <![CDATA[ 0 ]]>
+          </Price>
+        </Extension>
+        <Extension type="Count">
+          <!-- -->
+          <![CDATA[ 4 ]]>
+        </Extension>
+        <Extension>
+            { foo: bar }
+        </Extension>
+      </Extensions>
+    </InLine>
+  </Ad>
+</VAST>
+`;

--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -1,93 +1,202 @@
-export const inlineTrackers = `
-<VAST version="2.1">
-  <Ad id="ad_id_0001" sequence="1">
-    <InLine>
-      <AdSystem version="2.0"><![CDATA[AdServer]]></AdSystem>
-      <AdTitle><![CDATA[Ad title]]></AdTitle>
-      <Advertiser id='advertiser-desc'><![CDATA[Advertiser name]]></Advertiser>
-      <Description><![CDATA[Description text]]></Description>
-      <Pricing model="CPM" currency="USD"><![CDATA[1.09]]></Pricing>
-      <Survey><![CDATA[http://example.com/survey]]></Survey>
-      <Error><![CDATA[http://example.com/error_[ERRORCODE]]]></Error>
-      <Impression id="sample-impression1"><![CDATA[http://example.com/impression1_asset:[ASSETURI]_[CACHEBUSTING]]]></Impression>
-      <Impression id="sample-impression2"><![CDATA[http://example.com/impression2_[random]]]></Impression>
-      <Impression id="sample-impression3"><![CDATA[http://example.com/impression3_[RANDOM]]]></Impression>
-      <AdVerifications>
-        <Verification vendor="company.com-omid">
-          <JavaScriptResource apiFramework="omid" browserOptional="true">
-            <![CDATA[http://example.com/omid1]]>
-          </JavaScriptResource>
-        </Verification>
-        <Verification vendor="company2.com-omid">
-          <JavaScriptResource apiFramework="omid" browserOptional="false">
-            <![CDATA[http://example.com/omid2]]>
-          </JavaScriptResource>
-          <VerificationParameters>
-            <![CDATA[test-verification-parameter]]>
-          </VerificationParameters>
-        </Verification>
-      </AdVerifications>
-      <Creatives>
-        <Creative id="id130984" adId="adId345690" sequence="1">
-          <Linear>
-            <Duration>00:01:30.123</Duration>
-            <TrackingEvents>
-              <Tracking event="midpoint"><![CDATA[http://example.com/linear-midpoint]]></Tracking>
-              <Tracking event="complete"><![CDATA[http://example.com/linear-complete]]></Tracking>
-              <Tracking event="start"><![CDATA[http://example.com/linear-start]]></Tracking>
-              <Tracking event="firstQuartile"><![CDATA[http://example.com/linear-firstQuartile]]></Tracking>
-              <Tracking event="close"><![CDATA[http://example.com/linear-close]]></Tracking>
-              <Tracking event="thirdQuartile"><![CDATA[http://example.com/linear-thirdQuartile]]></Tracking>
-              <Tracking event="progress" offset="00:00:30.000"><![CDATA[http://example.com/linear-progress-30sec]]></Tracking>
-              <Tracking event="progress" offset="60%"><![CDATA[http://example.com/linear-progress-60%]]></Tracking>
-              <Tracking event="otherAdInteraction"><![CDATA[http://example.com/linear-otherAdInteraction]]></Tracking>
-              <Tracking event="acceptInvitation"><![CDATA[http://example.com/linear-acceptInvitation]]></Tracking>
-              <Tracking event="adExpand"><![CDATA[http://example.com/linear-adExpand]]></Tracking>
-              <Tracking event="adCollapse"><![CDATA[http://example.com/linear-adCollapse]]></Tracking>
-              <Tracking event="minimize"><![CDATA[http://example.com/linear-minimize]]></Tracking>
-              <Tracking event="overlayViewDuration"><![CDATA[http://example.com/linear-overlayViewDuration]]></Tracking>
-              <Tracking event="notUsed"><![CDATA[http://example.com/linear-notUsed]]></Tracking>
-            </TrackingEvents>
-            <VideoClicks>
-              <ClickTracking id='video-click-1'><![CDATA[http://example.com/linear-clicktracking1_ts:[TIMESTAMP]]]></ClickTracking>
-              <ClickTracking id='video-click-2'><![CDATA[http://example.com/linear-clicktracking2]]></ClickTracking>
-              <ClickThrough id='click-through'><![CDATA[http://example.com/linear-clickthrough]]></ClickThrough>
-              <CustomClick id='custom-click-1'><![CDATA[http://example.com/linear-customclick]]></CustomClick>
-            </VideoClicks>
-            <MediaFiles>
-              <MediaFile delivery="progressive" type="video/mp4" bitrate="849" width="512" height="288" scalable="true"><![CDATA[http://example.com/linear-asset.mp4]]></MediaFile>
-              <MediaFile apiFramework="VPAID" type="application/javascript" width="512" height="288" delivery="progressive"><![CDATA[parser.js?adData=http%3A%2F%2Fad.com%2F%3Fcb%3D%5Btime%5D]]></MediaFile>
-              <Mezzanine id="mezzanine-id-165468451" type="video/mp4" width="1080" height="720" delivery="progressive" codec="h264" fileSize="700"><![CDATA[http://example.com/linear-mezzanine.mp4]]></Mezzanine>
-            </MediaFiles>
-            <Icons>
-              <Icon program="ad1" width="60" height="20" xPosition="left" yPosition="bottom" duration="00:01:30.000" offset="00:00:15.000" apiFramework="VPAID" pxratio="2">
-                <StaticResource creativeType="image/gif"><![CDATA[http://example.com/linear-icon.gif]]></StaticResource>
-                <IconViewTracking><![CDATA[http://example.com/linear-viewtracking]]></IconViewTracking>
-                <IconClicks>
-                  <IconClickThrough><![CDATA[http://example.com/linear-clickthrough]]></IconClickThrough>
-                  <IconClickTracking id='icon-click-1'><![CDATA[http://example.com/linear-clicktracking1]]></IconClickTracking>
-                  <IconClickTracking id='icon-click-2'><![CDATA[http://example.com/linear-clicktracking2]]></IconClickTracking>
-                </IconClicks>
-              </Icon>
-            </Icons>
-          </Linear>
-        </Creative>
-      </Creatives>
-      <Extensions>
-        <Extension type="Pricing">
-          <Price model="CPM" currency="USD" source="someone">
-            <![CDATA[ 0 ]]>
-          </Price>
-        </Extension>
-        <Extension type="Count">
-          <!-- -->
-          <![CDATA[ 4 ]]>
-        </Extension>
-        <Extension>
-            { foo: bar }
-        </Extension>
-      </Extensions>
-    </InLine>
-  </Ad>
-</VAST>
-`;
+export const inlineTrackersParsed = {
+  ads: [
+    {
+      id: 'ad_id_0001',
+      sequence: '1',
+      system: { value: 'AdServer', version: '2.0' },
+      title: 'Ad title',
+      description: 'Description text',
+      advertiser: { id: 'advertiser-desc', value: 'Advertiser name' },
+      pricing: { value: '1.09', model: 'CPM', currency: 'USD' },
+      survey: 'http://example.com/survey',
+      errorURLTemplates: ['http://example.com/error_[ERRORCODE]'],
+      impressionURLTemplates: [
+        {
+          id: 'sample-impression1',
+          url: 'http://example.com/impression1_asset:[ASSETURI]_[CACHEBUSTING]'
+        },
+        {
+          id: 'sample-impression2',
+          url: 'http://example.com/impression2_[random]'
+        },
+        {
+          id: 'sample-impression3',
+          url: 'http://example.com/impression3_[RANDOM]'
+        }
+      ],
+      creatives: [
+        {
+          id: 'id130984',
+          adId: 'adId345690',
+          sequence: '1',
+          apiFramework: null,
+          type: 'linear',
+          duration: 90.123,
+          skipDelay: null,
+          mediaFiles: [
+            {
+              id: null,
+              fileURL: 'http://example.com/linear-asset.mp4',
+              deliveryType: 'progressive',
+              mimeType: 'video/mp4',
+              codec: null,
+              bitrate: 849,
+              minBitrate: 0,
+              maxBitrate: 0,
+              width: 512,
+              height: 288,
+              apiFramework: null,
+              scalable: true,
+              maintainAspectRatio: null
+            },
+            {
+              id: null,
+              fileURL:
+                'parser.js?adData=http%3A%2F%2Fad.com%2F%3Fcb%3D%5Btime%5D',
+              deliveryType: 'progressive',
+              mimeType: 'application/javascript',
+              codec: null,
+              bitrate: 0,
+              minBitrate: 0,
+              maxBitrate: 0,
+              width: 512,
+              height: 288,
+              apiFramework: 'VPAID',
+              scalable: null,
+              maintainAspectRatio: null
+            }
+          ],
+          mezzanine: {
+            id: 'mezzanine-id-165468451',
+            fileURL: 'http://example.com/linear-mezzanine.mp4',
+            delivery: 'progressive',
+            codec: 'h264',
+            type: 'video/mp4',
+            width: 1080,
+            height: 720,
+            fileSize: 700,
+            mediaType: '2D'
+          },
+          videoClickThroughURLTemplate: {
+            id: 'click-through',
+            url: 'http://example.com/linear-clickthrough'
+          },
+          videoClickTrackingURLTemplates: [
+            {
+              id: 'video-click-1',
+              url: 'http://example.com/linear-clicktracking1_ts:[TIMESTAMP]'
+            },
+            {
+              id: 'video-click-2',
+              url: 'http://example.com/linear-clicktracking2'
+            }
+          ],
+          videoCustomClickURLTemplates: [
+            {
+              id: 'custom-click-1',
+              url: 'http://example.com/linear-customclick'
+            }
+          ],
+          adParameters: null,
+          icons: [
+            {
+              program: 'ad1',
+              height: 20,
+              width: 60,
+              xPosition: 'left',
+              yPosition: 'bottom',
+              apiFramework: 'VPAID',
+              offset: 15,
+              duration: 90,
+              type: 'image/gif',
+              staticResource: 'http://example.com/linear-icon.gif',
+              htmlResource: null,
+              iframeResource: null,
+              pxratio: '2',
+              iconClickThroughURLTemplate:
+                'http://example.com/linear-clickthrough',
+              iconClickTrackingURLTemplates: [
+                {
+                  id: 'icon-click-1',
+                  url: 'http://example.com/linear-clicktracking1'
+                },
+                {
+                  id: 'icon-click-2',
+                  url: 'http://example.com/linear-clicktracking2'
+                }
+              ],
+              iconViewTrackingURLTemplate:
+                'http://example.com/linear-viewtracking'
+            }
+          ],
+          trackingEvents: {
+            midpoint: ['http://example.com/linear-midpoint'],
+            complete: ['http://example.com/linear-complete'],
+            start: ['http://example.com/linear-start'],
+            firstQuartile: ['http://example.com/linear-firstQuartile'],
+            close: ['http://example.com/linear-close'],
+            thirdQuartile: ['http://example.com/linear-thirdQuartile'],
+            'progress-30': ['http://example.com/linear-progress-30sec'],
+            'progress-60%': ['http://example.com/linear-progress-60%'],
+            otherAdInteraction: [
+              'http://example.com/linear-otherAdInteraction'
+            ],
+            acceptInvitation: ['http://example.com/linear-acceptInvitation'],
+            adExpand: ['http://example.com/linear-adExpand'],
+            adCollapse: ['http://example.com/linear-adCollapse'],
+            minimize: ['http://example.com/linear-minimize'],
+            overlayViewDuration: [
+              'http://example.com/linear-overlayViewDuration'
+            ],
+            notUsed: ['http://example.com/linear-notUsed']
+          }
+        }
+      ],
+      extensions: [
+        {
+          name: 'Extension',
+          value: null,
+          attributes: { type: 'Pricing' },
+          children: [
+            {
+              name: 'Price',
+              value: '0',
+              attributes: { model: 'CPM', currency: 'USD', source: 'someone' },
+              children: []
+            }
+          ]
+        },
+        {
+          name: 'Extension',
+          value: '4',
+          attributes: { type: 'Count' },
+          children: []
+        },
+        {
+          name: 'Extension',
+          value: '{ foo: bar }',
+          attributes: {},
+          children: []
+        }
+      ],
+      adVerifications: [
+        {
+          resource: 'http://example.com/omid1',
+          vendor: 'company.com-omid',
+          browserOptional: true,
+          apiFramework: 'omid',
+          parameters: null
+        },
+        {
+          resource: 'http://example.com/omid2',
+          vendor: 'company2.com-omid',
+          browserOptional: false,
+          apiFramework: 'omid',
+          parameters: 'test-verification-parameter'
+        }
+      ]
+    }
+  ],
+  errorURLTemplates: [],
+  version: '2.1'
+};

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -37,12 +37,10 @@ describe('VASTTracker', function() {
           vastTracker.minimize();
         });
 
-        it('should have sent minimize event', () => {
+        it('should have emitted minimize event and called trackUrl', () => {
           expect(spyEmitter).toHaveBeenCalledWith('minimize', {
             trackingURLTemplates: ['http://example.com/linear-minimize']
           });
-        });
-        it('should call trackURLs', () => {
           expect(spyTrackUrl).toHaveBeenCalledWith([
             'http://example.com/linear-minimize'
           ]);
@@ -54,14 +52,12 @@ describe('VASTTracker', function() {
           vastTracker.otherAdInteraction();
         });
 
-        it('should have sent otherAdInteraction event', () => {
+        it('should have emitted otherAdInteraction event and called trackUrl', () => {
           expect(spyEmitter).toHaveBeenCalledWith('otherAdInteraction', {
             trackingURLTemplates: [
               'http://example.com/linear-otherAdInteraction'
             ]
           });
-        });
-        it('should call trackURLs', () => {
           expect(spyTrackUrl).toHaveBeenCalledWith([
             'http://example.com/linear-otherAdInteraction'
           ]);
@@ -73,12 +69,10 @@ describe('VASTTracker', function() {
           vastTracker.acceptInvitation();
         });
 
-        it('should have sent acceptInvitation event', () => {
+        it('should have emitted acceptInvitation event and called trackUrl', () => {
           expect(spyEmitter).toHaveBeenCalledWith('acceptInvitation', {
             trackingURLTemplates: ['http://example.com/linear-acceptInvitation']
           });
-        });
-        it('should call trackURLs', () => {
           expect(spyTrackUrl).toHaveBeenCalledWith([
             'http://example.com/linear-acceptInvitation'
           ]);
@@ -90,12 +84,10 @@ describe('VASTTracker', function() {
           vastTracker.adExpand();
         });
 
-        it('should have sent adExpand event', () => {
+        it('should have emitted adExpand event and called trackUrl', () => {
           expect(spyEmitter).toHaveBeenCalledWith('adExpand', {
             trackingURLTemplates: ['http://example.com/linear-adExpand']
           });
-        });
-        it('should call trackURLs', () => {
           expect(spyTrackUrl).toHaveBeenCalledWith([
             'http://example.com/linear-adExpand'
           ]);
@@ -107,12 +99,10 @@ describe('VASTTracker', function() {
           vastTracker.adCollapse();
         });
 
-        it('should have sent adCollapse event', () => {
+        it('should have emitted adCollapse event and called trackUrl', () => {
           expect(spyEmitter).toHaveBeenCalledWith('adCollapse', {
             trackingURLTemplates: ['http://example.com/linear-adCollapse']
           });
-        });
-        it('should call trackURLs', () => {
           expect(spyTrackUrl).toHaveBeenCalledWith([
             'http://example.com/linear-adCollapse'
           ]);
@@ -124,17 +114,32 @@ describe('VASTTracker', function() {
           vastTracker.overlayViewDuration();
         });
 
-        it('should have sent adExpand event', () => {
+        it('should have emitted adExpand event and called trackUrl', () => {
           expect(spyEmitter).toHaveBeenCalledWith('overlayViewDuration', {
             trackingURLTemplates: [
               'http://example.com/linear-overlayViewDuration'
             ]
           });
-        });
-        it('should call trackURLs', () => {
           expect(spyTrackUrl).toHaveBeenCalledWith([
             'http://example.com/linear-overlayViewDuration'
           ]);
+        });
+      });
+
+      describe('#notUsed', () => {
+        it('should have emitted adExpand event and called trackUrl', () => {
+          vastTracker.notUsed();
+          expect(spyEmitter).toHaveBeenCalledWith('notUsed', {
+            trackingURLTemplates: ['http://example.com/linear-notUsed']
+          });
+          expect(spyTrackUrl).toHaveBeenCalledWith([
+            'http://example.com/linear-notUsed'
+          ]);
+        });
+
+        it('should not emitted any other event', () => {
+          vastTracker.adCollapse();
+          expect(spyEmitter).not.toHaveBeenCalled();
         });
       });
     });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -10,8 +10,10 @@ describe('VASTTracker', function() {
   describe('#linear', () => {
     let spyEmitter;
     let spyTrackUrl;
+    let adTrackingUrls;
     beforeEach(() => {
       const ad = inlineTrackersParsed.ads[0];
+      adTrackingUrls = ad.creatives[0].trackingEvents;
       vastTracker = new VASTTracker(vastClient, ad, ad.creatives[0]);
       spyEmitter = jest.spyOn(vastTracker, 'emit');
       spyTrackUrl = jest.spyOn(vastTracker, 'trackURLs');
@@ -24,11 +26,9 @@ describe('VASTTracker', function() {
 
       it('should have emitted minimize event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('minimize', {
-          trackingURLTemplates: ['http://example.com/linear-minimize']
+          trackingURLTemplates: adTrackingUrls.minimize
         });
-        expect(spyTrackUrl).toHaveBeenCalledWith([
-          'http://example.com/linear-minimize'
-        ]);
+        expect(spyTrackUrl).toHaveBeenCalledWith(adTrackingUrls.minimize);
       });
     });
 
@@ -39,11 +39,11 @@ describe('VASTTracker', function() {
 
       it('should have emitted otherAdInteraction event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('otherAdInteraction', {
-          trackingURLTemplates: ['http://example.com/linear-otherAdInteraction']
+          trackingURLTemplates: adTrackingUrls.otherAdInteraction
         });
-        expect(spyTrackUrl).toHaveBeenCalledWith([
-          'http://example.com/linear-otherAdInteraction'
-        ]);
+        expect(spyTrackUrl).toHaveBeenCalledWith(
+          adTrackingUrls.otherAdInteraction
+        );
       });
     });
 
@@ -54,11 +54,11 @@ describe('VASTTracker', function() {
 
       it('should have emitted acceptInvitation event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('acceptInvitation', {
-          trackingURLTemplates: ['http://example.com/linear-acceptInvitation']
+          trackingURLTemplates: adTrackingUrls.acceptInvitation
         });
-        expect(spyTrackUrl).toHaveBeenCalledWith([
-          'http://example.com/linear-acceptInvitation'
-        ]);
+        expect(spyTrackUrl).toHaveBeenCalledWith(
+          adTrackingUrls.acceptInvitation
+        );
       });
     });
 
@@ -69,11 +69,9 @@ describe('VASTTracker', function() {
 
       it('should have emitted adExpand event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('adExpand', {
-          trackingURLTemplates: ['http://example.com/linear-adExpand']
+          trackingURLTemplates: adTrackingUrls.adExpand
         });
-        expect(spyTrackUrl).toHaveBeenCalledWith([
-          'http://example.com/linear-adExpand'
-        ]);
+        expect(spyTrackUrl).toHaveBeenCalledWith(adTrackingUrls.adExpand);
       });
     });
 
@@ -84,28 +82,24 @@ describe('VASTTracker', function() {
 
       it('should have emitted adCollapse event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('adCollapse', {
-          trackingURLTemplates: ['http://example.com/linear-adCollapse']
+          trackingURLTemplates: adTrackingUrls.adCollapse
         });
-        expect(spyTrackUrl).toHaveBeenCalledWith([
-          'http://example.com/linear-adCollapse'
-        ]);
+        expect(spyTrackUrl).toHaveBeenCalledWith(adTrackingUrls.adCollapse);
       });
     });
 
     describe('#overlayViewDuration', () => {
       beforeEach(() => {
-        vastTracker.overlayViewDuration();
+        vastTracker.overlayViewDuration('00:00:30');
       });
 
       it('should have emitted adExpand event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('overlayViewDuration', {
-          trackingURLTemplates: [
-            'http://example.com/linear-overlayViewDuration'
-          ]
+          trackingURLTemplates: adTrackingUrls.overlayViewDuration
         });
-        expect(spyTrackUrl).toHaveBeenCalledWith([
-          'http://example.com/linear-overlayViewDuration'
-        ]);
+        expect(spyTrackUrl).toHaveBeenCalledWith(
+          adTrackingUrls.overlayViewDuration
+        );
       });
     });
 
@@ -115,11 +109,9 @@ describe('VASTTracker', function() {
         vastTracker.adCollapse();
 
         expect(spyEmitter).toHaveBeenCalledWith('notUsed', {
-          trackingURLTemplates: ['http://example.com/linear-notUsed']
+          trackingURLTemplates: adTrackingUrls.notUsed
         });
-        expect(spyTrackUrl).toHaveBeenCalledWith([
-          'http://example.com/linear-notUsed'
-        ]);
+        expect(spyTrackUrl).toHaveBeenCalledWith(adTrackingUrls.notUsed);
         expect(spyEmitter).toHaveBeenCalledTimes(1);
       });
     });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -5,126 +5,122 @@ import { inlineTrackersParsed } from '../spec/samples/inline_trackers';
 const vastClient = new VASTClient();
 
 describe('VASTTracker', function() {
-  describe('#constructor', function() {
-    let vastTracker = null;
+  let vastTracker = null;
 
-    describe('#linear', () => {
-      let spyEmitter;
-      let spyTrackUrl;
+  describe('#linear', () => {
+    let spyEmitter;
+    let spyTrackUrl;
+    beforeEach(() => {
+      const ad = inlineTrackersParsed.ads[0];
+      vastTracker = new VASTTracker(vastClient, ad, ad.creatives[0]);
+      spyEmitter = jest.spyOn(vastTracker, 'emit');
+      spyTrackUrl = jest.spyOn(vastTracker, 'trackURLs');
+    });
+
+    describe('#minimize', () => {
       beforeEach(() => {
-        const ad = inlineTrackersParsed.ads[0];
-        vastTracker = new VASTTracker(vastClient, ad, ad.creatives[0]);
-        spyEmitter = jest.spyOn(vastTracker, 'emit');
-        spyTrackUrl = jest.spyOn(vastTracker, 'trackURLs');
+        vastTracker.minimize();
       });
 
-      describe('#minimize', () => {
-        beforeEach(() => {
-          vastTracker.minimize();
+      it('should have emitted minimize event and called trackUrl', () => {
+        expect(spyEmitter).toHaveBeenCalledWith('minimize', {
+          trackingURLTemplates: ['http://example.com/linear-minimize']
         });
+        expect(spyTrackUrl).toHaveBeenCalledWith([
+          'http://example.com/linear-minimize'
+        ]);
+      });
+    });
 
-        it('should have emitted minimize event and called trackUrl', () => {
-          expect(spyEmitter).toHaveBeenCalledWith('minimize', {
-            trackingURLTemplates: ['http://example.com/linear-minimize']
-          });
-          expect(spyTrackUrl).toHaveBeenCalledWith([
-            'http://example.com/linear-minimize'
-          ]);
-        });
+    describe('#otherAdInteraction', () => {
+      beforeEach(() => {
+        vastTracker.otherAdInteraction();
       });
 
-      describe('#otherAdInteraction', () => {
-        beforeEach(() => {
-          vastTracker.otherAdInteraction();
+      it('should have emitted otherAdInteraction event and called trackUrl', () => {
+        expect(spyEmitter).toHaveBeenCalledWith('otherAdInteraction', {
+          trackingURLTemplates: ['http://example.com/linear-otherAdInteraction']
         });
+        expect(spyTrackUrl).toHaveBeenCalledWith([
+          'http://example.com/linear-otherAdInteraction'
+        ]);
+      });
+    });
 
-        it('should have emitted otherAdInteraction event and called trackUrl', () => {
-          expect(spyEmitter).toHaveBeenCalledWith('otherAdInteraction', {
-            trackingURLTemplates: [
-              'http://example.com/linear-otherAdInteraction'
-            ]
-          });
-          expect(spyTrackUrl).toHaveBeenCalledWith([
-            'http://example.com/linear-otherAdInteraction'
-          ]);
-        });
+    describe('#acceptInvitation', () => {
+      beforeEach(() => {
+        vastTracker.acceptInvitation();
       });
 
-      describe('#acceptInvitation', () => {
-        beforeEach(() => {
-          vastTracker.acceptInvitation();
+      it('should have emitted acceptInvitation event and called trackUrl', () => {
+        expect(spyEmitter).toHaveBeenCalledWith('acceptInvitation', {
+          trackingURLTemplates: ['http://example.com/linear-acceptInvitation']
         });
+        expect(spyTrackUrl).toHaveBeenCalledWith([
+          'http://example.com/linear-acceptInvitation'
+        ]);
+      });
+    });
 
-        it('should have emitted acceptInvitation event and called trackUrl', () => {
-          expect(spyEmitter).toHaveBeenCalledWith('acceptInvitation', {
-            trackingURLTemplates: ['http://example.com/linear-acceptInvitation']
-          });
-          expect(spyTrackUrl).toHaveBeenCalledWith([
-            'http://example.com/linear-acceptInvitation'
-          ]);
-        });
+    describe('#adExpand', () => {
+      beforeEach(() => {
+        vastTracker.adExpand();
       });
 
-      describe('#adExpand', () => {
-        beforeEach(() => {
-          vastTracker.adExpand();
+      it('should have emitted adExpand event and called trackUrl', () => {
+        expect(spyEmitter).toHaveBeenCalledWith('adExpand', {
+          trackingURLTemplates: ['http://example.com/linear-adExpand']
         });
+        expect(spyTrackUrl).toHaveBeenCalledWith([
+          'http://example.com/linear-adExpand'
+        ]);
+      });
+    });
 
-        it('should have emitted adExpand event and called trackUrl', () => {
-          expect(spyEmitter).toHaveBeenCalledWith('adExpand', {
-            trackingURLTemplates: ['http://example.com/linear-adExpand']
-          });
-          expect(spyTrackUrl).toHaveBeenCalledWith([
-            'http://example.com/linear-adExpand'
-          ]);
-        });
+    describe('#adCollapse', () => {
+      beforeEach(() => {
+        vastTracker.adCollapse();
       });
 
-      describe('#adCollapse', () => {
-        beforeEach(() => {
-          vastTracker.adCollapse();
+      it('should have emitted adCollapse event and called trackUrl', () => {
+        expect(spyEmitter).toHaveBeenCalledWith('adCollapse', {
+          trackingURLTemplates: ['http://example.com/linear-adCollapse']
         });
+        expect(spyTrackUrl).toHaveBeenCalledWith([
+          'http://example.com/linear-adCollapse'
+        ]);
+      });
+    });
 
-        it('should have emitted adCollapse event and called trackUrl', () => {
-          expect(spyEmitter).toHaveBeenCalledWith('adCollapse', {
-            trackingURLTemplates: ['http://example.com/linear-adCollapse']
-          });
-          expect(spyTrackUrl).toHaveBeenCalledWith([
-            'http://example.com/linear-adCollapse'
-          ]);
-        });
+    describe('#overlayViewDuration', () => {
+      beforeEach(() => {
+        vastTracker.overlayViewDuration();
       });
 
-      describe('#overlayViewDuration', () => {
-        beforeEach(() => {
-          vastTracker.overlayViewDuration();
-        });
-
-        it('should have emitted adExpand event and called trackUrl', () => {
-          expect(spyEmitter).toHaveBeenCalledWith('overlayViewDuration', {
-            trackingURLTemplates: [
-              'http://example.com/linear-overlayViewDuration'
-            ]
-          });
-          expect(spyTrackUrl).toHaveBeenCalledWith([
+      it('should have emitted adExpand event and called trackUrl', () => {
+        expect(spyEmitter).toHaveBeenCalledWith('overlayViewDuration', {
+          trackingURLTemplates: [
             'http://example.com/linear-overlayViewDuration'
-          ]);
+          ]
         });
+        expect(spyTrackUrl).toHaveBeenCalledWith([
+          'http://example.com/linear-overlayViewDuration'
+        ]);
       });
+    });
 
-      describe('#notUsed', () => {
-        it('should have emitted adExpand event, called trackUrl and not emitted any other event', () => {
-          vastTracker.notUsed();
-          vastTracker.adCollapse();
+    describe('#notUsed', () => {
+      it('should have emitted adExpand event, called trackUrl and not emitted any other event', () => {
+        vastTracker.notUsed();
+        vastTracker.adCollapse();
 
-          expect(spyEmitter).toHaveBeenCalledWith('notUsed', {
-            trackingURLTemplates: ['http://example.com/linear-notUsed']
-          });
-          expect(spyTrackUrl).toHaveBeenCalledWith([
-            'http://example.com/linear-notUsed'
-          ]);
-          expect(spyEmitter).toHaveBeenCalledTimes(1);
+        expect(spyEmitter).toHaveBeenCalledWith('notUsed', {
+          trackingURLTemplates: ['http://example.com/linear-notUsed']
         });
+        expect(spyTrackUrl).toHaveBeenCalledWith([
+          'http://example.com/linear-notUsed'
+        ]);
+        expect(spyEmitter).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -23,7 +23,9 @@ describe('VASTTracker', function() {
       beforeEach(() => {
         vastTracker.minimize();
       });
-
+      it('should be defined', () => {
+        expect(adTrackingUrls.minimize).toBeDefined();
+      });
       it('should have emitted minimize event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('minimize', {
           trackingURLTemplates: adTrackingUrls.minimize
@@ -36,7 +38,9 @@ describe('VASTTracker', function() {
       beforeEach(() => {
         vastTracker.otherAdInteraction();
       });
-
+      it('should be defined', () => {
+        expect(adTrackingUrls.otherAdInteraction).toBeDefined();
+      });
       it('should have emitted otherAdInteraction event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('otherAdInteraction', {
           trackingURLTemplates: adTrackingUrls.otherAdInteraction
@@ -51,7 +55,9 @@ describe('VASTTracker', function() {
       beforeEach(() => {
         vastTracker.acceptInvitation();
       });
-
+      it('should be defined', () => {
+        expect(adTrackingUrls.acceptInvitation).toBeDefined();
+      });
       it('should have emitted acceptInvitation event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('acceptInvitation', {
           trackingURLTemplates: adTrackingUrls.acceptInvitation
@@ -66,7 +72,9 @@ describe('VASTTracker', function() {
       beforeEach(() => {
         vastTracker.adExpand();
       });
-
+      it('should be defined', () => {
+        expect(adTrackingUrls.adExpand).toBeDefined();
+      });
       it('should have emitted adExpand event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('adExpand', {
           trackingURLTemplates: adTrackingUrls.adExpand
@@ -79,7 +87,9 @@ describe('VASTTracker', function() {
       beforeEach(() => {
         vastTracker.adCollapse();
       });
-
+      it('should be defined', () => {
+        expect(adTrackingUrls.adCollapse).toBeDefined();
+      });
       it('should have emitted adCollapse event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('adCollapse', {
           trackingURLTemplates: adTrackingUrls.adCollapse
@@ -92,7 +102,9 @@ describe('VASTTracker', function() {
       beforeEach(() => {
         vastTracker.overlayViewDuration('00:00:30');
       });
-
+      it('should be defined', () => {
+        expect(adTrackingUrls.overlayViewDuration).toBeDefined();
+      });
       it('should have emitted adExpand event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('overlayViewDuration', {
           trackingURLTemplates: adTrackingUrls.overlayViewDuration
@@ -104,6 +116,9 @@ describe('VASTTracker', function() {
     });
 
     describe('#notUsed', () => {
+      it('should be defined', () => {
+        expect(adTrackingUrls.notUsed).toBeDefined();
+      });
       it('should have emitted adExpand event, called trackUrl and not emitted any other event', () => {
         vastTracker.notUsed();
         vastTracker.adCollapse();

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -1,0 +1,142 @@
+import { VASTClient } from '../src/vast_client';
+import { VASTParser } from '../src/parser/vast_parser';
+import { VASTTracker } from '../src/vast_tracker';
+import { inlineTrackers } from '../spec/samples/inline_trackers';
+
+const vastParser = new VASTParser();
+const vastClient = new VASTClient();
+
+describe('VASTTracker', function() {
+  describe('#constructor', function() {
+    let vastTracker = null;
+    let response = {};
+
+    beforeAll(done => {
+      const vastXml = new window.DOMParser().parseFromString(
+        inlineTrackers,
+        'text/xml'
+      );
+      vastParser.parseVAST(vastXml).then(res => {
+        response = res;
+        done();
+      });
+    });
+
+    describe('#linear', () => {
+      let spyEmitter;
+      let spyTrackUrl;
+      beforeAll(() => {
+        const ad = response.ads[0];
+        vastTracker = new VASTTracker(vastClient, ad, ad.creatives[0]);
+        spyEmitter = jest.spyOn(vastTracker, 'emit');
+        spyTrackUrl = jest.spyOn(vastTracker, 'trackURLs');
+      });
+
+      describe('#minimize', () => {
+        beforeEach(() => {
+          vastTracker.minimize();
+        });
+
+        it('should have sent minimize event', () => {
+          expect(spyEmitter).toHaveBeenCalledWith('minimize', {
+            trackingURLTemplates: ['http://example.com/linear-minimize']
+          });
+        });
+        it('should call trackURLs', () => {
+          expect(spyTrackUrl).toHaveBeenCalledWith([
+            'http://example.com/linear-minimize'
+          ]);
+        });
+      });
+
+      describe('#otherAdInteraction', () => {
+        beforeEach(() => {
+          vastTracker.otherAdInteraction();
+        });
+
+        it('should have sent otherAdInteraction event', () => {
+          expect(spyEmitter).toHaveBeenCalledWith('otherAdInteraction', {
+            trackingURLTemplates: [
+              'http://example.com/linear-otherAdInteraction'
+            ]
+          });
+        });
+        it('should call trackURLs', () => {
+          expect(spyTrackUrl).toHaveBeenCalledWith([
+            'http://example.com/linear-otherAdInteraction'
+          ]);
+        });
+      });
+
+      describe('#acceptInvitation', () => {
+        beforeEach(() => {
+          vastTracker.acceptInvitation();
+        });
+
+        it('should have sent acceptInvitation event', () => {
+          expect(spyEmitter).toHaveBeenCalledWith('acceptInvitation', {
+            trackingURLTemplates: ['http://example.com/linear-acceptInvitation']
+          });
+        });
+        it('should call trackURLs', () => {
+          expect(spyTrackUrl).toHaveBeenCalledWith([
+            'http://example.com/linear-acceptInvitation'
+          ]);
+        });
+      });
+
+      describe('#adExpand', () => {
+        beforeEach(() => {
+          vastTracker.adExpand();
+        });
+
+        it('should have sent adExpand event', () => {
+          expect(spyEmitter).toHaveBeenCalledWith('adExpand', {
+            trackingURLTemplates: ['http://example.com/linear-adExpand']
+          });
+        });
+        it('should call trackURLs', () => {
+          expect(spyTrackUrl).toHaveBeenCalledWith([
+            'http://example.com/linear-adExpand'
+          ]);
+        });
+      });
+
+      describe('#adCollapse', () => {
+        beforeEach(() => {
+          vastTracker.adCollapse();
+        });
+
+        it('should have sent adCollapse event', () => {
+          expect(spyEmitter).toHaveBeenCalledWith('adCollapse', {
+            trackingURLTemplates: ['http://example.com/linear-adCollapse']
+          });
+        });
+        it('should call trackURLs', () => {
+          expect(spyTrackUrl).toHaveBeenCalledWith([
+            'http://example.com/linear-adCollapse'
+          ]);
+        });
+      });
+
+      describe('#overlayViewDuration', () => {
+        beforeEach(() => {
+          vastTracker.overlayViewDuration();
+        });
+
+        it('should have sent adExpand event', () => {
+          expect(spyEmitter).toHaveBeenCalledWith('overlayViewDuration', {
+            trackingURLTemplates: [
+              'http://example.com/linear-overlayViewDuration'
+            ]
+          });
+        });
+        it('should call trackURLs', () => {
+          expect(spyTrackUrl).toHaveBeenCalledWith([
+            'http://example.com/linear-overlayViewDuration'
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -338,6 +338,85 @@ export class VASTTracker extends EventEmitter {
   }
 
   /**
+   * Must be called if the ad was not and will not be played
+   * This is a terminal event; no other tracking events should be sent when this is used.
+   * Calls the notUsed tracking URLs.
+   *
+   * @emits VASTTracker#notUsed
+   */
+  notUsed() {
+    this.track('notUsed');
+    this.trackingEvents = [];
+  }
+
+  /**
+   * An optional metric that can capture all other user interactions
+   * under one metric such as hover-overs, or custom clicks. It should NOT replace
+   * clickthrough events or other existing events like mute, unmute, pause, etc.
+   * Calls the otherAdInteraction tracking URLs.
+   *
+   * @emits VASTTracker#otherAdInteraction
+   */
+  otherAdInteraction() {
+    this.track('otherAdInteraction');
+  }
+
+  /**
+   * Must be called if the user clicked or otherwise activated a control used to
+   * pause streaming content,* which either expands the ad within the player’s
+   * viewable area or “takes-over” the streaming content area by launching
+   * additional portion of the ad.
+   * Calls the acceptInvitation tracking URLs.
+   *
+   * @emits VASTTracker#acceptInvitation
+   */
+  acceptInvitation() {
+    this.track('acceptInvitation');
+  }
+
+  /**
+   * Must be called if user activated a control to expand the creative.
+   * Calls the adExpand tracking URLs.
+   *
+   * @emits VASTTracker#adExpand
+   */
+  adExpand() {
+    this.track('adExpand');
+  }
+
+  /**
+   * Must be called when the user activated a control to reduce the creative to its original dimensions.
+   * Calls the adCollapse tracking URLs.
+   *
+   * @emits VASTTracker#adCollapse
+   */
+  adCollapse() {
+    this.track('adCollapse');
+  }
+
+  /**
+   * Must be called if the user clicked or otherwise activated a control used to minimize the ad.
+   * Calls the minimize tracking URLs.
+   * @emits VASTTracker#minimize
+   */
+  minimize() {
+    this.track('minimize');
+  }
+
+  /**
+   * The time that the initial ad is displayed. This time is based on
+   * the time between the impression and either the completed length of display based
+   * on the agreement between transactional parties or a close, minimize, or accept
+   * invitation event.
+   * The time has to be passed using [ADPLAYHEAD] and [MEDIAPLAYHEAD] for VAST 4.1
+   * Calls the overlayViewDuration tracking URLs.
+   * @emits VASTTracker#overlayViewDuration
+   */
+  overlayViewDuration() {
+    this.track('overlayViewDuration');
+  }
+
+  /**
    * Must be called when the player or the window is closed during the ad.
    * Calls the `closeLinear` (in VAST 3.0 and 4.1) and `close` tracking URLs.
    *

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -412,6 +412,7 @@ export class VASTTracker extends EventEmitter {
    * Calls the overlayViewDuration tracking URLs.
    * @emits VASTTracker#overlayViewDuration
    */
+  // TODO : Pass the duration as a parameter and replace the corresponding macro with it
   overlayViewDuration() {
     this.track('overlayViewDuration');
   }


### PR DESCRIPTION
### Description

Implemented following missing trackers:
- notUsed
- otherAdInteraction
- acceptInvitation
- adExpand
- adCollapse
- minimize
- overlayViewDuration

### Issue

[Implement missing VAST 4.1 trackers](https://github.com/dailymotion/vast-client-js/issues/316)

### TODO
- [x] Write unit tests
- [x] Edit documentation
### Type
- [x] Breaking change
- [x] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
