### PR TITLE
[tracker] Autofill ADTYPE, ADSERVINGID & ADCATEGORIES macros when set 

### DIFF
--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -96,6 +96,8 @@ The following macro value will be set automatically by vast-client if it exists 
 - ASSETURI
 - PODSEQUENCE
 - UNIVERSALADID
+- ADTYPE
+- ADSERVINGID
 
 For any others supported macros, they need to be passed as a parameter when calling tracking methods and must exists in tracking url to be replaced.
 
@@ -665,6 +667,8 @@ Also automatically replaces the deducted value for following macros:
 - ASSETURI
 - PODSEQUENCE
 - UNIVERSALADID
+- ADTYPE
+- ADSERVINGID
 
 #### Parameters
 * **`URLTemplates: Array<String|Object>`** - An array of tracking url templates.

--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -98,6 +98,7 @@ The following macro value will be set automatically by vast-client if it exists 
 - UNIVERSALADID
 - ADTYPE
 - ADSERVINGID
+- ADCATEGORIES
 
 For any others supported macros, they need to be passed as a parameter when calling tracking methods and must exists in tracking url to be replaced.
 
@@ -669,6 +670,7 @@ Also automatically replaces the deducted value for following macros:
 - UNIVERSALADID
 - ADTYPE
 - ADSERVINGID
+- ADCATEGORIES
 
 #### Parameters
 * **`URLTemplates: Array<String|Object>`** - An array of tracking url templates.

--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -3,6 +3,8 @@ export const inlineTrackersParsed = {
     {
       id: 'ad_id_0001',
       sequence: '1',
+      adType: 'video',
+      adServingId: 'z292x16y-3d7f-6440-bd29-2ec0f153fc89',
       system: { value: 'AdServer', version: '2.0' },
       title: 'Ad title',
       description: 'Description text',
@@ -141,7 +143,9 @@ export const inlineTrackersParsed = {
             otherAdInteraction: [
               'http://example.com/linear-otherAdInteraction'
             ],
-            acceptInvitation: ['http://example.com/linear-acceptInvitation'],
+            acceptInvitation: [
+              'http://example.com/linear-acceptInvitation?adServingId=[ADSERVINGID]&adtype=[ADTYPE]'
+            ],
             adExpand: ['http://example.com/linear-adExpand'],
             adCollapse: ['http://example.com/linear-adCollapse'],
             minimize: ['http://example.com/linear-minimize'],

--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -10,6 +10,20 @@ export const inlineTrackersParsed = {
       description: 'Description text',
       advertiser: { id: 'advertiser-desc', value: 'Advertiser name' },
       pricing: { value: '1.09', model: 'CPM', currency: 'USD' },
+      categories: [
+        {
+          authority: 'https://www.example.com/categoryauthority',
+          value: 'Category-A'
+        },
+        {
+          authority: 'https://www.example.com/categoryauthority',
+          value: 'Category-B'
+        },
+        {
+          authority: 'https://www.example.com/categoryauthority',
+          value: 'Category-C'
+        }
+      ],
       survey: 'http://example.com/survey',
       errorURLTemplates: ['http://example.com/error_[ERRORCODE]'],
       impressionURLTemplates: [
@@ -144,7 +158,7 @@ export const inlineTrackersParsed = {
               'http://example.com/linear-otherAdInteraction'
             ],
             acceptInvitation: [
-              'http://example.com/linear-acceptInvitation?adServingId=[ADSERVINGID]&adtype=[ADTYPE]'
+              'http://example.com/linear-acceptInvitation?category=[ADCATEGORIES]&adServingId=[ADSERVINGID]&adtype=[ADTYPE]'
             ],
             adExpand: ['http://example.com/linear-adExpand'],
             adCollapse: ['http://example.com/linear-adCollapse'],

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -17,7 +17,8 @@ describe('VASTTracker', function() {
       UNIVERSALADID: 'sample-registry%20000123',
       PODSEQUENCE: '1',
       ADSERVINGID: 'z292x16y-3d7f-6440-bd29-2ec0f153fc89',
-      ADTYPE: 'video'
+      ADTYPE: 'video',
+      ADCATEGORIES: 'Category-A%2CCategory-B%2CCategory-C'
     };
     beforeEach(() => {
       ad = inlineTrackersParsed.ads[0];
@@ -161,8 +162,9 @@ describe('VASTTracker', function() {
           adTrackingUrls.overlayViewDuration,
           expect.objectContaining({
             ...expectedMacros,
-            ADSERVINGID: 'z292x16y-3d7f-6440-bd29-2ec0f153fc89',
-            ADTYPE: 'video'
+            ADPLAYHEAD: '00%3A00%3A30',
+            CONTENTPLAYHEAD: '00%3A00%3A30',
+            MEDIAPLAYHEAD: '00%3A00%3A30'
           })
         );
       });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -12,6 +12,13 @@ describe('VASTTracker', function() {
     let spyTrackUrl;
     let adTrackingUrls;
     let ad;
+    const expectedMacros = {
+      ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
+      UNIVERSALADID: 'sample-registry%20000123',
+      PODSEQUENCE: '1',
+      ADSERVINGID: 'z292x16y-3d7f-6440-bd29-2ec0f153fc89',
+      ADTYPE: 'video'
+    };
     beforeEach(() => {
       ad = inlineTrackersParsed.ads[0];
       adTrackingUrls = ad.creatives[0].trackingEvents;
@@ -34,11 +41,7 @@ describe('VASTTracker', function() {
 
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.minimize,
-          expect.objectContaining({
-            ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
-            UNIVERSALADID: 'sample-registry%20000123',
-            PODSEQUENCE: '1'
-          })
+          expect.objectContaining(expectedMacros)
         );
       });
     });
@@ -84,11 +87,7 @@ describe('VASTTracker', function() {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.otherAdInteraction,
-          expect.objectContaining({
-            ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
-            UNIVERSALADID: 'sample-registry%20000123',
-            PODSEQUENCE: '1'
-          })
+          expect.objectContaining(expectedMacros)
         );
       });
     });
@@ -106,11 +105,7 @@ describe('VASTTracker', function() {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.acceptInvitation,
-          expect.objectContaining({
-            ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
-            UNIVERSALADID: 'sample-registry%20000123',
-            PODSEQUENCE: '1'
-          })
+          expect.objectContaining(expectedMacros)
         );
       });
     });
@@ -128,11 +123,7 @@ describe('VASTTracker', function() {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.adExpand,
-          expect.objectContaining({
-            ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
-            UNIVERSALADID: 'sample-registry%20000123',
-            PODSEQUENCE: '1'
-          })
+          expect.objectContaining(expectedMacros)
         );
       });
     });
@@ -150,11 +141,7 @@ describe('VASTTracker', function() {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.adCollapse,
-          expect.objectContaining({
-            ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
-            UNIVERSALADID: 'sample-registry%20000123',
-            PODSEQUENCE: '1'
-          })
+          expect.objectContaining(expectedMacros)
         );
       });
     });
@@ -173,9 +160,9 @@ describe('VASTTracker', function() {
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.overlayViewDuration,
           expect.objectContaining({
-            ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
-            UNIVERSALADID: 'sample-registry%20000123',
-            PODSEQUENCE: '1'
+            ...expectedMacros,
+            ADSERVINGID: 'z292x16y-3d7f-6440-bd29-2ec0f153fc89',
+            ADTYPE: 'video'
           })
         );
       });
@@ -194,11 +181,7 @@ describe('VASTTracker', function() {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.notUsed,
-          expect.objectContaining({
-            ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
-            UNIVERSALADID: 'sample-registry%20000123',
-            PODSEQUENCE: '1'
-          })
+          expect.objectContaining(expectedMacros)
         );
         expect(spyEmitter).toHaveBeenCalledTimes(1);
       });

--- a/src/util/macros.js
+++ b/src/util/macros.js
@@ -42,6 +42,6 @@ export const supportedMacros = [
   // The player need to pass it inside "macro" parameter when calling trackers
   'BLOCKEDADCATEGORIES',
   'ADCATEGORIES', // <Category> element is also not parsed for now. Same instructions as above
-  'ADTYPE', //adType attribute of <Ad> element is not parsed for now. Same instructions as above
-  'ADSERVINGID' // <AdServingId> element is also not parsed for now. Same instructions as above
+  'ADTYPE',
+  'ADSERVINGID'
 ];

--- a/src/util/macros.js
+++ b/src/util/macros.js
@@ -41,7 +41,7 @@ export const supportedMacros = [
   // can't replace the macro with element value automatically.
   // The player need to pass it inside "macro" parameter when calling trackers
   'BLOCKEDADCATEGORIES',
-  'ADCATEGORIES', // <Category> element is also not parsed for now. Same instructions as above
+  'ADCATEGORIES',
   'ADTYPE',
   'ADSERVINGID'
 ];

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -621,6 +621,11 @@ export class VASTTracker extends EventEmitter {
       if (this.ad.adServingId) {
         macros['ADSERVINGID'] = this.ad.adServingId;
       }
+      if (this.ad.categories && this.ad.categories.length) {
+        macros['ADCATEGORIES'] = this.ad.categories
+          .map(categorie => categorie.value)
+          .join(',');
+      }
     }
 
     util.track(URLTemplates, macros, options);

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -611,8 +611,16 @@ export class VASTTracker extends EventEmitter {
       }`;
     }
 
-    if (this.ad && this.ad.sequence) {
-      macros['PODSEQUENCE'] = this.ad.sequence;
+    if (this.ad) {
+      if (this.ad.sequence) {
+        macros['PODSEQUENCE'] = this.ad.sequence;
+      }
+      if (this.ad.adType) {
+        macros['ADTYPE'] = this.ad.adType;
+      }
+      if (this.ad.adServingId) {
+        macros['ADSERVINGID'] = this.ad.adServingId;
+      }
     }
 
     util.track(URLTemplates, macros, options);


### PR DESCRIPTION
### Description

Since vast-client now parse and support adType attribute of `<Ad>` element,`<AdServingId>` and `<Category>` elements, the macros `ADTYPE`, `ADSERVINGID` and `ADCATEGORIES`  can be replaced by their values automatically.
See https://github.com/dailymotion/vast-client-js/pull/342#discussion_r338631675

### Issue

This PR is related to #336 

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [x] Documentation
- [ ] Tooling
