### PR TITLE
Fix node_url_handler bad import

### DIFF
--- a/src/urlhandlers/node_url_handler.js
+++ b/src/urlhandlers/node_url_handler.js
@@ -1,9 +1,10 @@
+import { DEFAULT_TIMEOUT } from './consts';
+
 const uri = require('url');
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
 const DOMParser = require('xmldom').DOMParser;
-const { DEFAULT_TIMEOUT } = require('./consts');
 
 function get(url, options, cb) {
   url = uri.parse(url);


### PR DESCRIPTION
### Description

Vast-client built node file (from 3.0.0-alpha.7) throws error:
```
Error: Cannot find module './consts'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/node_modules/vast-client/dist/vast-client-node.min.js:1:30219)
```
Because of import that is not transpiled by babel.

### Type
- [ ] Breaking change
- [ ] Enhancement
- [x] Fix
- [ ] Documentation
- [ ] Tooling
