### PR TITLE
Merge Wrapper adVerification with current unwrapped adVerification 

### DIFF
--- a/spec/ad_parser.spec.js
+++ b/spec/ad_parser.spec.js
@@ -2,6 +2,7 @@ import { parseAd, _parseViewableImpression } from '../src/parser/ad_parser';
 import { getNodesFromXml } from './utils/utils';
 import { parserUtils } from '../src/parser/parser_utils';
 import { linearAd } from './samples/linear_ads';
+import { adVerificationExtensions } from './samples/ad_verification_extentions';
 import {
   viewableImpression,
   viewableImpressionPartial
@@ -178,6 +179,39 @@ describe('AdParser', function() {
         'http://example.com/verification-not-executed-EXE',
         'http://sample.com/verification-not-executed-EXE'
       ]);
+    });
+  });
+
+  describe('adVerifications from extensions', function() {
+    let adVerificationExtensionsNode, ad;
+
+    beforeAll(() => {
+      adVerificationExtensionsNode = getNodesFromXml(adVerificationExtensions);
+      ad = parseAd(adVerificationExtensionsNode, null).ad;
+    });
+
+    it('should have 2 adVerifications', () => {
+      expect(ad.adVerifications).toHaveLength(2);
+    });
+
+    it('validate first adVerification', () => {
+      expect(ad.adVerifications[0].resource).toEqual('https://abc.com/omid.js');
+      expect(ad.adVerifications[0].vendor).toEqual('abc.com-omid');
+      expect(ad.adVerifications[0].browserOptional).toEqual(true);
+      expect(ad.adVerifications[0].apiFramework).toEqual('omid');
+      expect(ad.adVerifications[0].type).toBeUndefined;
+      expect(ad.adVerifications[0].parameters).toBeUndefined;
+    });
+
+    it('validate second adVerification', () => {
+      expect(ad.adVerifications[1].resource).toEqual(
+        'https://xyz.com/omid-verify.js'
+      );
+      expect(ad.adVerifications[1].vendor).toEqual('xyz.com-omidpub');
+      expect(ad.adVerifications[1].browserOptional).toEqual(true);
+      expect(ad.adVerifications[1].apiFramework).toEqual('omid');
+      expect(ad.adVerifications[1].type).toBeUndefined;
+      expect(ad.adVerifications[1].parameters).toBeUndefined;
     });
   });
 

--- a/spec/samples/ad_verification_extentions.js
+++ b/spec/samples/ad_verification_extentions.js
@@ -1,0 +1,54 @@
+export const adVerificationExtensions = `<Ad id="ad_id_0001" sequence="1" adType="video">
+  <InLine>
+    <AdSystem version="2.0" ><![CDATA[AdServer]]></AdSystem>
+    <AdTitle><![CDATA[Ad title]]></AdTitle>
+    <Description><![CDATA[Description text]]></Description>
+    <Error><![CDATA[http://example.com/error_[ERRORCODE]]]></Error>
+    <Impression id="sample-impression1"><![CDATA[http://example.com/impression1_asset:[ASSETURI]_[CACHEBUSTING]]]></Impression>
+    <Creatives>
+      <Creative id="id130984" adId="adId345690" sequence="1" >
+        <Linear>
+          <Duration>00:01:30.123</Duration>
+          <MediaFiles>
+            <MediaFile delivery="progressive" type="video/mp4" bitrate="849" width="512" height="288" scalable="true" fileSize="345670"><![CDATA[http://example.com/linear-asset.mp4]]></MediaFile>
+          </MediaFiles>
+        </Linear>
+      </Creative>
+    </Creatives>
+    <Extensions>
+      <Extension type="Pricing">
+        <Price model="CPM" currency="USD" source="someone">
+          <![CDATA[ 0 ]]>
+        </Price>
+      </Extension>
+      <Extension type="Count">
+        <!-- -->
+        <![CDATA[ 4 ]]>
+      </Extension>
+      <Extension>
+          { foo: bar }
+      </Extension>
+      <Extension type="AdVerifications">
+        <AdVerifications>
+          <Verification vendor="abc.com-omid">
+            <JavaScriptResource apiFramework="omid" browserOptional="true">
+              <![CDATA[https://abc.com/omid.js]]>
+            </JavaScriptResource>
+            <VerificationParameters><![CDATA[...]]></VerificationParameters>
+            <TrackingEvents>
+              <Tracking event="verificationNotExecuted">
+                <![CDATA[https://abc.com/omid_reject?r=[REASON]]]>
+              </Tracking>
+            </TrackingEvents>
+          </Verification>
+          <Verification vendor="xyz.com-omidpub">
+            <JavaScriptResource apiFramework="omid" browserOptional="true">
+              <![CDATA[https://xyz.com/omid-verify.js]]>
+            </JavaScriptResource>
+            <VerificationParameters><![CDATA[...]]></VerificationParameters>
+          </Verification>
+        </AdVerifications>
+      </Extension>
+    </Extensions>
+  </InLine>
+</Ad>`;

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -48,29 +48,40 @@ describe('VASTTracker', function() {
     });
 
     describe('#verificationNotExecuted', () => {
-      let verificationUrls;
+      let verificationUrl;
       let reasonMacro = { REASON: 3 };
+      const vendor = 'company.com-omid';
       beforeEach(() => {
-        verificationUrls =
+        verificationUrl =
           ad.adVerifications[0].trackingEvents.verificationNotExecuted;
-        vastTracker.verificationNotExecuted(reasonMacro);
+        vastTracker.verificationNotExecuted(vendor, reasonMacro);
       });
       it('should be defined', () => {
-        expect(verificationUrls).toBeDefined();
+        expect(verificationUrl).toBeDefined();
       });
       it('should have emitted verificationNotExecuted event and called trackUrl', () => {
         expect(spyTrackUrl).toHaveBeenCalledWith(
-          verificationUrls,
+          verificationUrl,
           expect.objectContaining(reasonMacro)
         );
         expect(spyEmitter).toHaveBeenCalledWith('verificationNotExecuted', {
-          trackingURLTemplates: verificationUrls
+          trackingURLTemplates: verificationUrl
         });
+      });
+      it('should throw missing AdVerification vendor error', () => {
+        const vendor = ad.adVerifications[0].vendor;
+        ad.adVerifications[0].vendor = null;
+        expect(() => {
+          vastTracker.verificationNotExecuted(vendor, reasonMacro);
+        }).toThrowError(
+          'No associated verification element found for vendor: company.com-omid'
+        );
+        ad.adVerifications[0].vendor = vendor;
       });
       it('should throw missing AdVerification error', () => {
         ad.adVerifications.length = 0;
         expect(() => {
-          vastTracker.verificationNotExecuted(reasonMacro);
+          vastTracker.verificationNotExecuted(vendor, reasonMacro);
         }).toThrowError('No adVerifications provided');
       });
     });

--- a/src/parser/parser_utils.js
+++ b/src/parser/parser_utils.js
@@ -311,6 +311,13 @@ function mergeWrapperAdData(unwrappedAd, wrapper) {
       });
     }
   });
+  // As specified by VAST specs unwrapped ads should contains wrapper adVerification script
+  if (wrapper.adVerifications) {
+    unwrappedAd.adVerifications = [
+      ...unwrappedAd.adVerifications,
+      ...wrapper.adVerifications
+    ];
+  }
 }
 
 export const parserUtils = {

--- a/src/parser/parser_utils.js
+++ b/src/parser/parser_utils.js
@@ -313,10 +313,9 @@ function mergeWrapperAdData(unwrappedAd, wrapper) {
   });
   // As specified by VAST specs unwrapped ads should contains wrapper adVerification script
   if (wrapper.adVerifications) {
-    unwrappedAd.adVerifications = [
-      ...unwrappedAd.adVerifications,
-      ...wrapper.adVerifications
-    ];
+    unwrappedAd.adVerifications = unwrappedAd.adVerifications.concat(
+      wrapper.adVerifications
+    );
   }
 }
 

--- a/test/vast_parser.js
+++ b/test/vast_parser.js
@@ -132,43 +132,75 @@ describe('VASTParser', function() {
         ad1.extensions.should.have.length(4);
       });
 
-      it('should have 3 AdVerification URLs VAST 4.1', () => {
-        ad1.adVerifications.should.have.length(3);
+      it('should have 5 AdVerification URLs VAST 4.1', () => {
+        ad1.adVerifications.should.have.length(5);
       });
 
       it('validate second adVerification', () => {
-        ad1.adVerifications[1].resource.should.eql('http://example.com/omid2');
-        ad1.adVerifications[1].vendor.should.eql('company2.com-omid');
-        ad1.adVerifications[1].browserOptional.should.eql(false);
-        ad1.adVerifications[1].apiFramework.should.eql('omid');
-        ad1.adVerifications[1].parameters.should.eql(
-          'test-verification-parameter'
-        );
-        ad1.adVerifications[1].trackingEvents.should.have.keys(
+        const adVerification = ad1.adVerifications[1];
+        adVerification.resource.should.eql('http://example.com/omid2');
+        adVerification.vendor.should.eql('company2.com-omid');
+        adVerification.browserOptional.should.eql(false);
+        adVerification.apiFramework.should.eql('omid');
+        adVerification.parameters.should.eql('test-verification-parameter');
+        adVerification.trackingEvents.should.have.keys(
           'verificationNotExecuted'
         );
-        ad1.adVerifications[1].trackingEvents[
-          'verificationNotExecuted'
-        ].should.eql(['http://example.com/verification-not-executed-JS']);
+        adVerification.trackingEvents['verificationNotExecuted'].should.eql([
+          'http://example.com/verification-not-executed-JS'
+        ]);
       });
 
       it('validate third adVerification', () => {
-        ad1.adVerifications[2].resource.should.eql(
-          'http://example.com/omid1.exe'
-        );
-        ad1.adVerifications[2].vendor.should.eql('company.daily.com-omid');
-        ad1.adVerifications[2].browserOptional.should.eql(false);
-        ad1.adVerifications[2].apiFramework.should.eql('omid');
-        ad1.adVerifications[2].type.should.eql('executable');
-        should.equal(ad1.adVerifications[2].parameters, null);
-        ad1.adVerifications[2].trackingEvents.should.have.keys(
+        const adVerification = ad1.adVerifications[2];
+        adVerification.resource.should.eql('http://example.com/omid1.exe');
+        adVerification.vendor.should.eql('company.daily.com-omid');
+        adVerification.browserOptional.should.eql(false);
+        adVerification.apiFramework.should.eql('omid');
+        adVerification.type.should.eql('executable');
+        should.equal(adVerification.parameters, null);
+        adVerification.trackingEvents.should.have.keys(
           'verificationNotExecuted'
         );
-        ad1.adVerifications[2].trackingEvents[
-          'verificationNotExecuted'
-        ].should.eql([
+        adVerification.trackingEvents['verificationNotExecuted'].should.eql([
           'http://example.com/verification-not-executed-EXE',
           'http://sample.com/verification-not-executed-EXE'
+        ]);
+      });
+
+      it('validate wrapper-b adVerification merging', () => {
+        const adVerification = ad1.adVerifications[3];
+        adVerification.resource.should.eql(
+          'https://verification-b.com/omid_verification.js'
+        );
+        adVerification.vendor.should.eql('verification-b.com-omid');
+        adVerification.browserOptional.should.eql(false);
+        adVerification.apiFramework.should.eql('omid');
+        adVerification.parameters.should.eql(
+          'parameterB1=valueB1&parameterB2=valueB2'
+        );
+        adVerification.trackingEvents.should.not.have.keys(
+          'verificationNotExecuted'
+        );
+      });
+
+      it('validate wrapper-a adVerification merging', () => {
+        const adVerification = ad1.adVerifications[4];
+
+        adVerification.resource.should.eql(
+          'https://verification-a.com/omid_verification.js'
+        );
+        adVerification.vendor.should.eql('verification-a.com-omid');
+        adVerification.browserOptional.should.eql(false);
+        adVerification.apiFramework.should.eql('omid');
+        adVerification.parameters.should.eql(
+          'parameterA1=valueA1&parameterA2=valueA2'
+        );
+        adVerification.trackingEvents.should.have.keys(
+          'verificationNotExecuted'
+        );
+        adVerification.trackingEvents['verificationNotExecuted'].should.eql([
+          'http://verification-a.com/verification-A-not-executed-JS'
         ]);
       });
 

--- a/test/vastfiles/sample.xml
+++ b/test/vastfiles/sample.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<VAST version="2.1">
+<VAST version="4.1">
   <Ad id="ad_id_0001" sequence="1">
     <InLine>
-      <AdSystem version="2.0" ><![CDATA[AdServer]]></AdSystem>
+      <AdSystem version="2.0"><![CDATA[AdServer]]></AdSystem>
       <AdTitle><![CDATA[Ad title]]></AdTitle>
       <Advertiser id='advertiser-desc'><![CDATA[Advertiser name]]></Advertiser>
       <Description><![CDATA[Description text]]></Description>
-      <Pricing model="CPM" currency="USD" ><![CDATA[1.09]]></Pricing>
+      <Pricing model="CPM" currency="USD"><![CDATA[1.09]]></Pricing>
       <Survey><![CDATA[http://example.com/survey]]></Survey>
       <Error><![CDATA[http://example.com/error_[ERRORCODE]]]></Error>
       <Impression id="sample-impression1"><![CDATA[http://example.com/impression1_asset:[ASSETURI]_[CACHEBUSTING]]]></Impression>
@@ -40,7 +40,7 @@
         </Verification>
       </AdVerifications>
       <Creatives>
-        <Creative id="id130984" adId="adId345690" sequence="1" >
+        <Creative id="id130984" adId="adId345690" sequence="1">
           <UniversalAdId idRegistry="daily-motion-L">Linear-12345</UniversalAdId>
           <CreativeExtensions>
             <CreativeExtension type="creativeExt1">
@@ -106,7 +106,7 @@
             </Icons>
           </Linear>
         </Creative>
-        <Creative id="id130985" AdID="adId345691" sequence="2" >
+        <Creative id="id130985" AdID="adId345691" sequence="2">
           <CompanionAds>
             <Companion width="300" height="60">
               <StaticResource creativeType="image/jpeg"><![CDATA[http://example.com/companion1-static-resource]]></StaticResource>
@@ -141,7 +141,7 @@
         <Creative id="id130986">
           <UniversalAdId idRegistry="daily-motion-NL">NonLinear-12345</UniversalAdId>
           <NonLinearAds>
-            <NonLinear width="300" height="200" expandedWidth="600" expandedHeight="400" scalable="false" maintainAspectRatio="true" minSuggestedDuration="00:01:40" apiFramework="someAPI" >
+            <NonLinear width="300" height="200" expandedWidth="600" expandedHeight="400" scalable="false" maintainAspectRatio="true" minSuggestedDuration="00:01:40" apiFramework="someAPI">
               <StaticResource creativeType="image/jpeg"><![CDATA[http://example.com/nonlinear-static-resource]]></StaticResource>
               <AdParameters>
                 <![CDATA[{"key":"value"}]]>
@@ -179,13 +179,13 @@
   </Ad>
   <Ad id="ad_id_0002">
     <InLine>
-      <AdSystem version="2.1" ><![CDATA[AdServer2]]></AdSystem>
+      <AdSystem version="2.1"><![CDATA[AdServer2]]></AdSystem>
       <AdTitle><![CDATA[Ad title 2]]></AdTitle>
       <Impression id="sample-ad2-impression1"><![CDATA[http://example.com/impression1]]></Impression>
       <Creatives>
         <Creative id="id873421" adID="adId221144" apiFramework="VPAID">
           <UniversalAdId>Linear-id873421</UniversalAdId>
-          <Linear skipoffset="00:00:10" >
+          <Linear skipoffset="00:00:10">
             <Duration>30</Duration>
             <MediaFiles>
               <MediaFile delivery="progressive" type="application/javascript" width="512" height="288" apiFramework="VPAID"><![CDATA[http://example.com/vpaid.js]]></MediaFile>

--- a/test/vastfiles/wrapper-a.xml
+++ b/test/vastfiles/wrapper-a.xml
@@ -6,6 +6,17 @@
       <VASTAdTagURI><![CDATA[wrapper-b.xml]]></VASTAdTagURI>
       <Error><![CDATA[http://example.com/wrapperA-error]]></Error>
       <Impression id="wrapper-a-impression"><![CDATA[http://example.com/wrapperA-impression]]></Impression>
+      <AdVerifications>
+        <Verification vendor="verification-a.com-omid">
+          <JavaScriptResource apiFramework="omid" browserOptional="false">
+            <![CDATA[https://verification-a.com/omid_verification.js]]>
+          </JavaScriptResource>
+          <VerificationParameters><![CDATA[parameterA1=valueA1&parameterA2=valueA2]]></VerificationParameters>
+          <TrackingEvents>
+            <Tracking event="verificationNotExecuted"><![CDATA[http://verification-a.com/verification-A-not-executed-JS]]></Tracking>
+          </TrackingEvents>
+        </Verification>
+      </AdVerifications>
       <Creatives>
         <Creative id="a:ca1">
           <CompanionAds>

--- a/test/vastfiles/wrapper-b.xml
+++ b/test/vastfiles/wrapper-b.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<VAST version="2.0">
+<VAST version="4.1">
   <Ad>
     <Wrapper>
       <AdSystem>VAST</AdSystem>
@@ -7,6 +7,14 @@
       <Error><![CDATA[http://example.com/wrapperB-error]]></Error>
       <Impression id="wrapper-b-impression1"><![CDATA[http://example.com/wrapperB-impression1]]></Impression>
       <Impression id="wrapper-b-impression2"><![CDATA[http://example.com/wrapperB-impression2]]></Impression>
+      <AdVerifications>
+        <Verification vendor="verification-b.com-omid">
+          <JavaScriptResource apiFramework="omid" browserOptional="false">
+            <![CDATA[https://verification-b.com/omid_verification.js]]>
+          </JavaScriptResource>
+          <VerificationParameters><![CDATA[parameterB1=valueB1&parameterB2=valueB2]]></VerificationParameters>
+        </Verification>
+      </AdVerifications>
       <Creatives>
         <Creative id="b:ca1">
           <CompanionAds>


### PR DESCRIPTION
### Description
When a vast is unwrapped, the final vast, once parsed now contains its verifications script and also the one from previous wrapper. 

i.e for a InLine wrapped in two wrapper (Wrapper A -> Wrapper B -> InLineC)

- Wrapper A contains 2 verification script:
  - script_A_1
  - script_A_2

- Wrapper B contains 1 verification script: 
  - script_B

- InLine C contains 1 verification script: 
  - script_C

The final vast once parsed should contain AdVerifications object with all the verification scripts: 
- script_A_1, 
- script_A_2, 
- script_B,
- script_C

For more details please see the [VAST 4.1 specification ](https://iabtechlab.com/wp-content/uploads/2018/11/VAST4.1-final-Nov-8-2018.pdf#page=32
)
### Type
- [x] Breaking change
- [x] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
