### PR TITLE
Fix missing slash in the url for file path

### DIFF
--- a/spec/utils/utils.js
+++ b/spec/utils/utils.js
@@ -10,7 +10,7 @@ export const urlFor = fileName => {
   const filePath = path
     .resolve(path.join('spec', 'samples', fileName))
     .replace(/\\/g, '/');
-  return `file://${filePath}`;
+  return `file:///${filePath}`;
 };
 
 export const fetchXml = (url, options = {}) => {

--- a/test/vast_parser.js
+++ b/test/vast_parser.js
@@ -9,7 +9,7 @@ import { util } from '../src/util/util';
 const vastParser = new VASTParser();
 
 const urlfor = relpath =>
-  `file://${path
+  `file:///${path
     .resolve(path.dirname(module.filename), 'vastfiles', relpath)
     .replace(/\\/g, '/')}`;
 

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -15,7 +15,7 @@ const options = {
 };
 
 const urlfor = relpath =>
-  `file://${path
+  `file:///${path
     .resolve(path.dirname(module.filename), 'vastfiles', relpath)
     .replace(/\\/g, '/')}`;
 


### PR DESCRIPTION
Unit tests were broken on windows when changes from https://github.com/dailymotion/vast-client-js/pull/340#issuecomment-555022506 were merged. This PR fix it. 
