### PR TITLE
[tracker] Fix missing default value for optional parameter on public method 

### DIFF
--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -552,11 +552,11 @@ export class VASTTracker extends EventEmitter {
    * Calls the tracking URLs for the given eventName and emits the event.
    *
    * @param {String} eventName - The name of the event.
-   * @param {Object} [macros ={}] - An optional Object of parameters(vast macros) to be used in the tracking calls.
+   * @param {Object} [macros={}] - An optional Object of parameters(vast macros) to be used in the tracking calls.
    * @param {Boolean} [once=false] - Boolean to define if the event has to be tracked only once.
    *
    */
-  track(eventName, { macros = {}, once = false }) {
+  track(eventName, { macros = {}, once = false } = {}) {
     // closeLinear event was introduced in VAST 3.0
     // Fallback to vast 2.0 close event if necessary
     if (


### PR DESCRIPTION
### Description

On public method track of vast-tracker: `track(eventName, { macros, once })`
The following parameters are optional
- macros: Object - An optional Object of macros to be used in the tracking calls.
- once: Boolean - An optional Boolean to define if the event has to be tracked only once.

Those parameters are inside a destructed object, if the method track is called without this object it will trigger an error. As this is an optional object and given that this method is public, it should not cause any error.

### Type
- [ ] Breaking change
- [ ] Enhancement
- [x] Fix
- [ ] Documentation
- [ ] Tooling
