### PR TITLE
Keep wrapper sequence value when containing only one final ad

### DIFF
--- a/spec/parser_utils.spec.js
+++ b/spec/parser_utils.spec.js
@@ -196,4 +196,380 @@ describe('ParserUtils', function() {
       document.body.innerHTML = '';
     });
   });
+
+  describe('mergeWrapperAdData', function() {
+    let unwrappedAd = {
+      id: null,
+      sequence: 1,
+      title: null,
+      description: null,
+      advertiser: null,
+      pricing: null,
+      survey: null,
+      errorURLTemplates: ['unwrappedAd1', 'unwrappedAd2'],
+      impressionURLTemplates: [
+        {
+          id: 'unwrappedAd',
+          url: 'https://unwrappedAd.com'
+        }
+      ],
+      creatives: [
+        {
+          type: 'companion',
+          trackingEvents: {
+            creativeView: [
+              'http://example.com/companion1-unwrappedAd-creativeview'
+            ]
+          },
+          variations: [
+            {
+              adType: 'companionAd',
+              companionClickTrackingURLTemplates: [
+                {
+                  id: '1',
+                  url:
+                    'http://example.com/companion1-unwrappedAd-clicktracking-first'
+                },
+                {
+                  id: '2',
+                  url:
+                    'http://example.com/companion1-unwrappedAd-clicktracking-second'
+                }
+              ]
+            },
+            {
+              type: 'linear',
+              videoClickThroughURLTemplate: null,
+              videoClickTrackingURLTemplates: [
+                {
+                  id: 'video-click-1',
+                  url:
+                    'http://example.com/linear-clicktracking1_ts:[TIMESTAMP]_adplayhead:[ADPLAYHEAD]'
+                }
+              ],
+              videoCustomClickURLTemplates: [
+                {
+                  id: 'custom-click-1',
+                  url: 'http://example.com/linear-customclick'
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      extensions: [
+        {
+          name: 'Extension',
+          value: null,
+          attributes: {
+            type: 'geo'
+          },
+          children: [
+            {
+              name: 'Country',
+              value: 'FR',
+              attributes: {},
+              children: []
+            },
+            {
+              name: 'Bandwidth',
+              value: '5',
+              attributes: {},
+              children: []
+            }
+          ]
+        }
+      ],
+      adVerifications: ['unwrappedAd'],
+      blockedAdCategories: ['unwrappedAd'],
+      trackingEvents: { nonlinear: [], linear: [] },
+      videoClickTrackingURLTemplates: [],
+      videoCustomClickURLTemplates: [],
+      followAdditionalWrappers: null,
+      allowMultipleAds: null,
+      fallbackOnNoAd: null
+    };
+    let wrapper = {
+      id: null,
+      sequence: 2,
+      title: null,
+      description: null,
+      advertiser: null,
+      pricing: null,
+      survey: null,
+      errorURLTemplates: ['wrapper1', 'wrapper2'],
+      impressionURLTemplates: [
+        {
+          id: 'wrapper1',
+          url: 'https://wrapper1.com'
+        },
+        {
+          id: 'wrapper2',
+          url: 'https://wrapper2.com'
+        }
+      ],
+      creatives: [
+        {
+          type: 'companion',
+          trackingEvents: {
+            creativeView: ['http://example.com/companion1-wrapper-creativeview']
+          },
+          variations: [
+            {
+              companionClickTrackingURLTemplates: [
+                {
+                  id: '1',
+                  url:
+                    'http://example.com/companion1-wrapper-clicktracking-first'
+                },
+                {
+                  id: '2',
+                  url:
+                    'http://example.com/companion1-wrapper-clicktracking-second'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          type: 'linear',
+          videoClickThroughURLTemplate: {
+            id: 'click-through',
+            url:
+              'http://example.com/linear-clickthrough_adplayhead:[ADPLAYHEAD]'
+          },
+          videoClickTrackingURLTemplates: [
+            {
+              id: 'video-click-1',
+              url:
+                'http://example.com/linear-clicktracking1_ts:[TIMESTAMP]_adplayhead:[ADPLAYHEAD]'
+            },
+            {
+              id: 'video-click-2',
+              url: 'http://example.com/linear-clicktracking2'
+            }
+          ],
+          videoCustomClickURLTemplates: [
+            {
+              id: 'custom-click-1',
+              url: 'http://example.com/linear-customclick'
+            }
+          ]
+        }
+      ],
+      extensions: [
+        {
+          name: 'Extension',
+          value: null,
+          attributes: {
+            type: 'geo'
+          },
+          children: [
+            {
+              name: 'Country',
+              value: 'US',
+              attributes: {},
+              children: []
+            },
+            {
+              name: 'Bandwidth',
+              value: '4',
+              attributes: {},
+              children: []
+            }
+          ]
+        }
+      ],
+      adVerifications: ['wrapper1', 'wrapper2'],
+      blockedAdCategories: ['wrapper1', 'wrapper2'],
+      trackingEvents: { nonlinear: [], linear: [] },
+      videoClickTrackingURLTemplates: [],
+      videoCustomClickURLTemplates: [],
+      followAdditionalWrappers: true,
+      allowMultipleAds: true,
+      fallbackOnNoAd: true
+    };
+
+    beforeAll(() => {
+      return parserUtils.mergeWrapperAdData(unwrappedAd, wrapper);
+    });
+
+    it('merge the wrapper and unwrappedAd errorURLTemplates together', function() {
+      expect(unwrappedAd.errorURLTemplates).toEqual([
+        'wrapper1',
+        'wrapper2',
+        'unwrappedAd1',
+        'unwrappedAd2'
+      ]);
+    });
+
+    it('merge the wrapper and unwrappedAd impressionURLTemplates together', function() {
+      expect(unwrappedAd.impressionURLTemplates).toEqual([
+        {
+          id: 'wrapper1',
+          url: 'https://wrapper1.com'
+        },
+        {
+          id: 'wrapper2',
+          url: 'https://wrapper2.com'
+        },
+        {
+          id: 'unwrappedAd',
+          url: 'https://unwrappedAd.com'
+        }
+      ]);
+    });
+
+    it('merge the wrapper and unwrappedAd extensions together', function() {
+      expect(unwrappedAd.extensions).toEqual([
+        {
+          attributes: {
+            type: 'geo'
+          },
+          children: [
+            {
+              attributes: {},
+              children: [],
+              name: 'Country',
+              value: 'US'
+            },
+            {
+              attributes: {},
+              children: [],
+              name: 'Bandwidth',
+              value: '4'
+            }
+          ],
+          name: 'Extension',
+          value: null
+        },
+        {
+          attributes: {
+            type: 'geo'
+          },
+          children: [
+            {
+              attributes: {},
+              children: [],
+              name: 'Country',
+              value: 'FR'
+            },
+            {
+              attributes: {},
+              children: [],
+              name: 'Bandwidth',
+              value: '5'
+            }
+          ],
+          name: 'Extension',
+          value: null
+        }
+      ]);
+    });
+
+    it('override unwrapped followAdditionalWrappers with wrapper one', function() {
+      expect(unwrappedAd.followAdditionalWrappers).toEqual(
+        wrapper.followAdditionalWrappers
+      );
+    });
+
+    it('override unwrapped allowMultipleAds with wrapper one', function() {
+      expect(unwrappedAd.allowMultipleAds).toEqual(wrapper.allowMultipleAds);
+    });
+
+    it('override unwrapped fallbackOnNoAd with wrapper one', function() {
+      expect(unwrappedAd.fallbackOnNoAd).toEqual(wrapper.fallbackOnNoAd);
+    });
+
+    it('merge the wrapper and unwrappedAd creatives together', function() {
+      expect(unwrappedAd.creatives).toEqual([
+        {
+          trackingEvents: {
+            creativeView: ['http://example.com/companion1-wrapper-creativeview']
+          },
+          type: 'companion',
+          variations: [
+            {
+              companionClickTrackingURLTemplates: [
+                {
+                  id: '1',
+                  url:
+                    'http://example.com/companion1-wrapper-clicktracking-first'
+                },
+                {
+                  id: '2',
+                  url:
+                    'http://example.com/companion1-wrapper-clicktracking-second'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          trackingEvents: {
+            creativeView: [
+              'http://example.com/companion1-unwrappedAd-creativeview'
+            ]
+          },
+          type: 'companion',
+          variations: [
+            {
+              adType: 'companionAd',
+              companionClickTrackingURLTemplates: [
+                {
+                  id: '1',
+                  url:
+                    'http://example.com/companion1-unwrappedAd-clicktracking-first'
+                },
+                {
+                  id: '2',
+                  url:
+                    'http://example.com/companion1-unwrappedAd-clicktracking-second'
+                },
+                {
+                  id: '1',
+                  url:
+                    'http://example.com/companion1-wrapper-clicktracking-first'
+                },
+                {
+                  id: '2',
+                  url:
+                    'http://example.com/companion1-wrapper-clicktracking-second'
+                }
+              ]
+            },
+            {
+              companionClickTrackingURLTemplates: [
+                {
+                  id: '1',
+                  url:
+                    'http://example.com/companion1-wrapper-clicktracking-first'
+                },
+                {
+                  id: '2',
+                  url:
+                    'http://example.com/companion1-wrapper-clicktracking-second'
+                }
+              ],
+              type: 'linear',
+              videoClickThroughURLTemplate: null,
+              videoClickTrackingURLTemplates: [
+                {
+                  id: 'video-click-1',
+                  url:
+                    'http://example.com/linear-clicktracking1_ts:[TIMESTAMP]_adplayhead:[ADPLAYHEAD]'
+                }
+              ],
+              videoCustomClickURLTemplates: [
+                {
+                  id: 'custom-click-1',
+                  url: 'http://example.com/linear-customclick'
+                }
+              ]
+            }
+          ]
+        }
+      ]);
+    });
+  });
 });

--- a/spec/vast_parser.spec.js
+++ b/spec/vast_parser.spec.js
@@ -686,6 +686,24 @@ describe('VASTParser', () => {
         expect(ads.length).toEqual(4);
       });
     });
+
+    it('it replaces the ad sequence with the value of the wrapper sequence if it contains only one ad', () => {
+      jest.spyOn(VastParser, 'parseVastXml').mockReturnValue([{ sequence: 2 }]);
+      return VastParser.parse(wrapperXml, { wrapperSequence: 4 }).then(ads => {
+        expect(ads[0].sequence).toEqual(4);
+      });
+    });
+
+    it('does not keep wrapper sequence value when wrapper contain an adpod', () => {
+      jest
+        .spyOn(VastParser, 'parseVastXml')
+        .mockReturnValue([{ sequence: 1 }, { sequence: 2 }, { sequence: 3 }]);
+      return VastParser.parse(wrapperXml, { wrapperSequence: 4 }).then(ads => {
+        expect(ads[0].sequence).toEqual(1);
+        expect(ads[1].sequence).toEqual(2);
+        expect(ads[2].sequence).toEqual(3);
+      });
+    });
   });
 
   describe('resolveAds', () => {

--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -396,19 +396,22 @@ export class VASTParser extends EventEmitter {
       return Promise.reject(e);
     }
 
-    const adsCount = ads.length;
-    const lastAddedAd = ads[adsCount - 1];
-    // if in child nodes we have only one ads
-    // and wrapperSequence is defined
-    // and this ads doesn't already have sequence
+    /* Keep wrapper sequence value to not break AdPod when wrapper contain only one Ad.
+    e.g,for a AdPod containing :
+    - Inline with sequence=1
+    - Inline with sequence=2
+    - Wrapper with sequence=3 wrapping a Inline with sequence=1
+    once parsed we will obtain :
+    - Inline sequence 1,
+    - Inline sequence 2,
+    - Inline sequence 3
+  */
     if (
-      adsCount === 1 &&
+      ads.length === 1 &&
       wrapperSequence !== undefined &&
-      wrapperSequence !== null &&
-      lastAddedAd &&
-      !lastAddedAd.sequence
+      wrapperSequence !== null
     ) {
-      lastAddedAd.sequence = wrapperSequence;
+      ads[0].sequence = wrapperSequence;
     }
 
     // Split the VAST in case we don't want to resolve everything at the first time


### PR DESCRIPTION
### Description

This PR will allow to replace the sequence attribute of an Inline ad by the one of its parent wrapper. the replacement will be made only if the wrapper contains only one ad. Otherwise sequences from the unwrapped ad will be kept.

e.g,for a use case where an AdPod contain:
```
- Inline with sequence 1
- Inline with sequence 2
- Wrapper with sequence 3 wrapping a Inline with sequence 1
```
once parsed we will obtain :
```
- Inline sequence 1,
- Inline sequence 2,
- Inline sequence 3
```

In the use case where a wrapper wrap an AdPod, the wrapper sequence will be ignored. 
e.g
```
- Wrapper sequence 3 containing:
  - Inline sequence 1,
  - Inline sequence 2,
  - Inline sequence 3
```
once parsed we will obtain :
```
- Inline sequence 1,
- Inline sequence 2,
- Inline sequence 3
```
### Issue

https://github.com/dailymotion/vast-client-js/issues/357

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
