### PR TITLE
[tracker] fix percentage tracker bug

### DIFF
--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -223,5 +223,29 @@ describe('VASTTracker', function() {
         expect(spyEmitter).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe('setProgress', () => {
+      let spyTrack;
+      let lastMock;
+      beforeEach(() => {
+        spyTrack = jest.spyOn(vastTracker, 'track');
+        vastTracker.assetDuration = 10;
+        //  vastTracker.lastDuration = 40;
+        vastTracker.setProgress(5);
+      });
+      it('call track with progress-5', () => {
+        expect(spyTrack).toHaveBeenCalledWith('progress-5', expect.anything());
+      });
+
+      it('call track with progress-50%', () => {
+        expect(spyTrack).toHaveBeenCalledWith(
+          'progress-50%',
+          expect.anything()
+        );
+      });
+      it('should have a lastPercentage variable', () => {
+        expect(vastTracker.lastPercentage).toBeDefined();
+      });
+    });
   });
 });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -226,7 +226,6 @@ describe('VASTTracker', function() {
 
     describe('setProgress', () => {
       let spyTrack;
-      let lastMock;
       beforeEach(() => {
         spyTrack = jest.spyOn(vastTracker, 'track');
         vastTracker.assetDuration = 10;
@@ -245,20 +244,14 @@ describe('VASTTracker', function() {
           expect.anything()
         );
       });
-      it('should have a lastPercentage variable', () => {
-        expect(vastTracker.lastPercentage).toBeDefined();
-      });
-      it('should make the lastPercentage variable at the value -1', () => {
+
+      it('should also calls track for previous missing percentages', () => {
         vastTracker.lastPercentage = 1;
-        expect(spyTrack).toHaveBeenCalledWith('progress-4%', expect.anything());
-      });
-      it('should make the lastPercentage variable at the value -1', () => {
-        vastTracker.lastPercentage = 1;
-        expect(spyTrack).toHaveBeenCalledWith('progress-3%', expect.anything());
-      });
-      it('should make the lastPercentage variable at the value -1', () => {
-        vastTracker.lastPercentage = 1;
-        expect(spyTrack).toHaveBeenCalledWith('progress-2%', expect.anything());
+        expect(spyTrack.mock.calls).toContainEqual(
+          ['progress-2%', expect.anything()],
+          ['progress-3%', expect.anything()],
+          ['progress-4%', expect.anything()]
+        );
       });
     });
   });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -231,20 +231,15 @@ describe('VASTTracker', function() {
         vastTracker.assetDuration = 10;
         vastTracker.setProgress(5);
       });
-      it('should be defined', () => {
-        expect(vastTracker.setProgress).toBeDefined();
-      });
       it('call track with progress-5', () => {
         expect(spyTrack).toHaveBeenCalledWith('progress-5', expect.anything());
       });
-
       it('call track with progress-50%', () => {
         expect(spyTrack).toHaveBeenCalledWith(
           'progress-50%',
           expect.anything()
         );
       });
-
       it('should also calls track for previous missing percentages', () => {
         vastTracker.lastPercentage = 1;
         expect(spyTrack.mock.calls).toContainEqual(

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -230,8 +230,10 @@ describe('VASTTracker', function() {
       beforeEach(() => {
         spyTrack = jest.spyOn(vastTracker, 'track');
         vastTracker.assetDuration = 10;
-        //  vastTracker.lastDuration = 40;
         vastTracker.setProgress(5);
+      });
+      it('should be defined', () => {
+        expect(vastTracker.setProgress).toBeDefined();
       });
       it('call track with progress-5', () => {
         expect(spyTrack).toHaveBeenCalledWith('progress-5', expect.anything());
@@ -245,6 +247,10 @@ describe('VASTTracker', function() {
       });
       it('should have a lastPercentage variable', () => {
         expect(vastTracker.lastPercentage).toBeDefined();
+      });
+      it('should make the lastPercentage variable at the value -1', () => {
+        vastTracker.lastPercentage = 1;
+        expect(spyTrack).toHaveBeenCalledWith('progress-4%', expect.anything());
       });
     });
   });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -252,6 +252,14 @@ describe('VASTTracker', function() {
         vastTracker.lastPercentage = 1;
         expect(spyTrack).toHaveBeenCalledWith('progress-4%', expect.anything());
       });
+      it('should make the lastPercentage variable at the value -1', () => {
+        vastTracker.lastPercentage = 1;
+        expect(spyTrack).toHaveBeenCalledWith('progress-3%', expect.anything());
+      });
+      it('should make the lastPercentage variable at the value -1', () => {
+        vastTracker.lastPercentage = 1;
+        expect(spyTrack).toHaveBeenCalledWith('progress-2%', expect.anything());
+      });
     });
   });
 });

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -37,9 +37,8 @@ export class VASTTracker extends EventEmitter {
     this.impressed = false;
     this.skippable = false;
     this.trackingEvents = {};
-    // We need to keep the last percentage of the tracker in order to
-    // calculate to trigger the events when the VAST duration is short
-    this.lastPercentage = 0; 
+    this.lastPercentage = 0; //We need to keep the last percentage of the tracker in order to
+    //calculate to trigger the events when the VAST duration is short
     // We need to save the already triggered quartiles, in order to not trigger them again
     this._alreadyTriggeredQuartiles = {};
     // Tracker listeners should be notified with some events
@@ -182,38 +181,33 @@ export class VASTTracker extends EventEmitter {
 
     if (this.assetDuration > 0) {
       const percent = Math.round((progress / this.assetDuration) * 100);
-      for (let i = this.lastPercentage; i < percent; i++) {
-        const events = [];
-        if (progress > 0) {
-          events.push('start');
+      const events = [];
+      if (progress > 0) {
+        events.push('start');
+        for (let i = this.lastPercentage; i < percent; i++) {
           events.push(`progress-${i + 1}%`);
-          events.push(`progress-${Math.round(progress)}`);
-          for (const quartile in this.quartiles) {
-            if (
-              this.isQuartileReached(
-                quartile,
-                this.quartiles[quartile],
-                progress
-              )
-            ) {
-              events.push(quartile);
-              this._alreadyTriggeredQuartiles[quartile] = true;
-            }
+        }
+        events.push(`progress-${Math.round(progress)}`);
+        for (const quartile in this.quartiles) {
+          if (
+            this.isQuartileReached(quartile, this.quartiles[quartile], progress)
+          ) {
+            events.push(quartile);
+            this._alreadyTriggeredQuartiles[quartile] = true;
           }
-          this.lastPercentage = percent;
         }
-
-        events.forEach(eventName => {
-          this.track(eventName, { macros, once: true });
-        });
-
-        if (progress < this.progress) {
-          this.track('rewind', { macros });
-        }
+        this.lastPercentage = percent;
       }
+      events.forEach(eventName => {
+        this.track(eventName, { macros, once: true });
+      });
 
-      this.progress = progress;
+      if (progress < this.progress) {
+        this.track('rewind', { macros });
+      }
     }
+
+    this.progress = progress;
   }
 
   /**

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -37,7 +37,8 @@ export class VASTTracker extends EventEmitter {
     this.impressed = false;
     this.skippable = false;
     this.trackingEvents = {};
-    this.lastPercentage = 0;
+    this.lastPercentage = 0; //We need to keep the last percentage of the tracker in order to
+    //calculate to trigger the events when the VAST duration is short
     // We need to save the already triggered quartiles, in order to not trigger them again
     this._alreadyTriggeredQuartiles = {};
     // Tracker listeners should be notified with some events
@@ -202,7 +203,7 @@ export class VASTTracker extends EventEmitter {
         }
 
         events.forEach(eventName => {
-          this.track(eventName,  { macros, once: true });
+          this.track(eventName, { macros, once: true });
         });
 
         if (progress < this.progress) {

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -37,9 +37,9 @@ export class VASTTracker extends EventEmitter {
     this.impressed = false;
     this.skippable = false;
     this.trackingEvents = {};
-    this.lastPercentage = 0; //We need to keep the last percentage of the tracker in order to
-    //calculate to trigger the events when the VAST duration is short
-    // We need to save the already triggered quartiles, in order to not trigger them again
+    // We need to keep the last percentage of the tracker in order to
+    // calculate to trigger the events when the VAST duration is short
+    this.lastPercentage = 0; 
     this._alreadyTriggeredQuartiles = {};
     // Tracker listeners should be notified with some events
     // no matter if there is a tracking URL or not

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -39,7 +39,7 @@ export class VASTTracker extends EventEmitter {
     this.trackingEvents = {};
     // We need to keep the last percentage of the tracker in order to
     // calculate to trigger the events when the VAST duration is short
-    this.lastPercentage = 0; 
+    this.lastPercentage = 0;
     this._alreadyTriggeredQuartiles = {};
     // Tracker listeners should be notified with some events
     // no matter if there is a tracking URL or not


### PR DESCRIPTION
### Description

The progress event is used to call trackers when the ad duration is equal to or greater than the value provided in an additional offset attribute for the Linear element. Offset values can be time in the format HH:MM:SS or HH:MM:SS.mmm or a percentage value in the format n%. 

For some VAST,  the calculation of the percentages was not accurate when the duration of the ad was short due to `const percent = Math.round((progress / this.assetDuration) * 100);`
Exemple: for an ad that last 10 sec, as each second is equivalent to 10% if we let the ad run for 2 seconds following tracker will be triggered (grossly simplified):
- progress-1 
- progress-10%
- progress-2
- progress-20%

As you can see, with the current calculation some intermediate percentages are missing therefore not called.  
This PR fix it.

### Type
- [ ] Breaking change
- [ ] Enhancement
- [x] Fix
- [ ] Documentation
- [ ] Tooling
