### PR TITLE
Make vastTracker.errorWithCode able to replace more than [ERRORCODE] macro

### DIFF
--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -333,7 +333,9 @@ export class VASTTracker extends EventEmitter {
       { isCustomCode }
     );
   }
-
+  error(macros = {}) {
+    this.trackURLs(this.ad.errorURLTemplates, { macros });
+  }
   /**
    * Must be called when the user watched the linear creative until its end.
    * Calls the complete tracking URLs.


### PR DESCRIPTION
### Description

Right now, vastTracker.errorWithCode only take the error code and only replace the [ERRORCODE] macro, we need to improve the function to also handle all other macros.

The idea : create a vastTracker.error() and take a macro object as for all other methods, and deprecate the other method.

### Type
- [ ] Breaking change
- [X] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
