### PR TITLE
 Make vastTracker.errorWithCode able to replace more than [ERRORCODE] macro

### DIFF
--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -282,8 +282,8 @@ describe('VASTTracker', function () {
         expect(spyTrack).not.toHaveBeenCalledTimes(2);
       });
     });
+
     describe('#error', () => {
-      let isCustomCode = false;
       it('should be called with the right arguments', () => {
         vastTracker.error();
         expect(spyTrackUrl).toHaveBeenCalledWith(
@@ -294,14 +294,12 @@ describe('VASTTracker', function () {
       });
     });
 
-    describe('#errorWithCode', () => {
+    fdescribe('#errorWithCode', () => {
       it('should be called with the right arguments', () => {
-        vastTracker.errorWithCode();
-        expect(spyTrackUrl).toHaveBeenCalledWith(
-          ['http://example.com/error_[ERRORCODE]'],
-          expect.objectContaining(expectedMacros),
-          { isCustomCode: false }
-        );
+        const spyError = jest.fn();
+        vastTracker.error = spyError;
+        vastTracker.errorWithCode('1234', true);
+        expect(spyError).toHaveBeenCalledWith({ ERRORCODE: '1234' }, true);
       });
     });
   });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -303,7 +303,6 @@ describe('VASTTracker', function () {
       });
     });
     describe('#errorWithCode', () => {
-      let errorCode = 404;
       beforeEach(() => {
         vastTracker.errorWithCode();
       });
@@ -313,7 +312,7 @@ describe('VASTTracker', function () {
       it('should hava called the error method', () => {
         expect(spyAdError).toHaveBeenCalledTimes(1);
       });
-      it('should have emitted adErrpr, called trackUrl and not emitted any other event', () => {
+      it('should have emitted an ad error, called trackUrl and not emitted any other event', () => {
         expect(spyTrackUrl).toHaveBeenCalledWith(
           ['http://example.com/error_[ERRORCODE]'],
           expect.objectContaining(expectedMacros),

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -120,7 +120,7 @@ describe('VASTTracker', function () {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.otherAdInteraction,
-          expect.objectContaining(expectedMacros)
+          expectedMacros
         );
       });
     });
@@ -138,7 +138,7 @@ describe('VASTTracker', function () {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.acceptInvitation,
-          expect.objectContaining(expectedMacros)
+          expectedMacros
         );
       });
     });
@@ -156,7 +156,7 @@ describe('VASTTracker', function () {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.adExpand,
-          expect.objectContaining(expectedMacros)
+          expectedMacros
         );
       });
     });
@@ -174,7 +174,7 @@ describe('VASTTracker', function () {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.adCollapse,
-          expect.objectContaining(expectedMacros)
+          expectedMacros
         );
       });
     });
@@ -219,7 +219,7 @@ describe('VASTTracker', function () {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.notUsed,
-          expect.objectContaining(expectedMacros)
+          expectedMacros
         );
         expect(spyEmitter).toHaveBeenCalledTimes(1);
       });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -20,20 +20,24 @@ describe('VASTTracker', function () {
       ADSERVINGID: 'z292x16y-3d7f-6440-bd29-2ec0f153fc89',
       ADTYPE: 'video',
       ADCATEGORIES: 'Category-A%2CCategory-B%2CCategory-C',
+      ADPLAYHEAD: '01%3A15%3A05.250',
     };
+
     beforeEach(() => {
       ad = inlineTrackersParsed.ads[0];
       adTrackingUrls = ad.creatives[0].trackingEvents;
       vastTracker = new VASTTracker(vastClient, ad, ad.creatives[0]);
       spyEmitter = jest.spyOn(vastTracker, 'emit');
       spyTrackUrl = jest.spyOn(vastTracker, 'trackURLs');
+      // spyTrackUrl = jest.fn();
+      // vastTracker.trackURLs = spyTrackUrl;
       spyTrack = jest.spyOn(vastTracker, 'track');
     });
 
     describe('#click', () => {
       beforeEach(() => {
         vastTracker.setProgress(60 * 75 + 5.25);
-        vastTracker.click();
+        vastTracker.click(null, expectedMacros);
       });
       it('should have emitted click event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith(
@@ -53,7 +57,7 @@ describe('VASTTracker', function () {
 
     describe('#minimize', () => {
       beforeEach(() => {
-        vastTracker.minimize();
+        vastTracker.minimize(expectedMacros);
       });
       it('should be defined', () => {
         expect(adTrackingUrls.minimize).toBeDefined();
@@ -111,7 +115,7 @@ describe('VASTTracker', function () {
 
     describe('#otherAdInteraction', () => {
       beforeEach(() => {
-        vastTracker.otherAdInteraction();
+        vastTracker.otherAdInteraction(expectedMacros);
       });
       it('should be defined', () => {
         expect(adTrackingUrls.otherAdInteraction).toBeDefined();
@@ -129,7 +133,7 @@ describe('VASTTracker', function () {
 
     describe('#acceptInvitation', () => {
       beforeEach(() => {
-        vastTracker.acceptInvitation();
+        vastTracker.acceptInvitation(expectedMacros);
       });
       it('should be defined', () => {
         expect(adTrackingUrls.acceptInvitation).toBeDefined();
@@ -147,7 +151,7 @@ describe('VASTTracker', function () {
 
     describe('#adExpand', () => {
       beforeEach(() => {
-        vastTracker.adExpand();
+        vastTracker.adExpand(expectedMacros);
       });
       it('should be defined', () => {
         expect(adTrackingUrls.adExpand).toBeDefined();
@@ -165,7 +169,7 @@ describe('VASTTracker', function () {
 
     describe('#adCollapse', () => {
       beforeEach(() => {
-        vastTracker.adCollapse();
+        vastTracker.adCollapse(expectedMacros);
       });
       it('should be defined', () => {
         expect(adTrackingUrls.adCollapse).toBeDefined();
@@ -182,11 +186,14 @@ describe('VASTTracker', function () {
     });
 
     describe('#overlayViewDuration', () => {
+      const overlayViewMacros = {
+        ADPLAYHEAD: '00:00:40',
+        CONTENTPLAYHEAD: '00:00:40',
+        MEDIAPLAYHEAD: '00:00:40',
+        ...expectedMacros,
+      };
       beforeEach(() => {
-        vastTracker.overlayViewDuration('00:00:30', {
-          CONTENTPLAYHEAD: '00:00:40',
-          MEDIAPLAYHEAD: '00:00:40',
-        });
+        vastTracker.overlayViewDuration('00:00:30', overlayViewMacros);
       });
       it('should be defined', () => {
         expect(adTrackingUrls.overlayViewDuration).toBeDefined();
@@ -197,12 +204,10 @@ describe('VASTTracker', function () {
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.overlayViewDuration,
-          expect.objectContaining({
-            ...expectedMacros,
-            ADPLAYHEAD: '00%3A00%3A30',
-            CONTENTPLAYHEAD: '00%3A00%3A40',
-            MEDIAPLAYHEAD: '00%3A00%3A40',
-          })
+          {
+            ...overlayViewMacros,
+            ADPLAYHEAD: '00:00:30',
+          }
         );
       });
     });
@@ -212,8 +217,8 @@ describe('VASTTracker', function () {
         expect(adTrackingUrls.notUsed).toBeDefined();
       });
       it('should have emitted adExpand event, called trackUrl and not emitted any other event', () => {
-        vastTracker.notUsed();
-        vastTracker.adCollapse();
+        vastTracker.notUsed(expectedMacros);
+        vastTracker.adCollapse(expectedMacros);
 
         expect(spyEmitter).toHaveBeenCalledWith('notUsed', {
           trackingURLTemplates: adTrackingUrls.notUsed,
@@ -285,16 +290,16 @@ describe('VASTTracker', function () {
 
     describe('#error', () => {
       it('should be called with the right arguments', () => {
-        vastTracker.error();
+        vastTracker.error(expectedMacros);
         expect(spyTrackUrl).toHaveBeenCalledWith(
           ['http://example.com/error_[ERRORCODE]'],
-          expect.objectContaining(expectedMacros),
+          expectedMacros,
           { isCustomCode: false }
         );
       });
     });
 
-    fdescribe('#errorWithCode', () => {
+    describe('#errorWithCode', () => {
       it('should be called with the right arguments', () => {
         const spyError = jest.fn();
         vastTracker.error = spyError;

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -13,8 +13,8 @@ describe('VASTTracker', function () {
     let spyTrack;
     let adTrackingUrls;
     let ad;
-    let isCustomCode = false;
     let spyAdError;
+    let isCustomCode;
     const expectedMacros = {
       ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
       UNIVERSALADID: 'sample-registry%20000123',
@@ -286,12 +286,9 @@ describe('VASTTracker', function () {
       });
     });
     describe('#error', () => {
-      let isCustomCode = false;
+      isCustomCode = false;
       beforeEach(() => {
         vastTracker.error();
-      });
-      it('should be defined', () => {
-        expect(ad.errorURLTemplates).toBeDefined();
       });
       it('should have emitted an ad Error and called trackUrl ', () => {
         expect(spyTrackUrl).toHaveBeenCalledWith(
@@ -306,19 +303,15 @@ describe('VASTTracker', function () {
       beforeEach(() => {
         vastTracker.errorWithCode();
       });
-      it('should be defined', () => {
-        expect(ad.errorURLTemplates).toBeDefined();
-      });
-      it('should hava called the error method', () => {
+      isCustomCode = false;
+      it('should have called the error method', () => {
         expect(spyAdError).toHaveBeenCalledTimes(1);
       });
-      it('should have emitted an ad error, called trackUrl and not emitted any other event', () => {
-        expect(spyTrackUrl).toHaveBeenCalledWith(
-          ['http://example.com/error_[ERRORCODE]'],
-          expect.objectContaining(expectedMacros),
-          expect.objectContaining({ isCustomCode })
+      it('called the error method with the right arguments', () => {
+        expect(spyAdError).toHaveBeenCalledWith(
+          expect.objectContaining({ ...expectedMacros }),
+          isCustomCode
         );
-        expect(spyTrackUrl).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -29,8 +29,6 @@ describe('VASTTracker', function () {
       vastTracker = new VASTTracker(vastClient, ad, ad.creatives[0]);
       spyEmitter = jest.spyOn(vastTracker, 'emit');
       spyTrackUrl = jest.spyOn(vastTracker, 'trackURLs');
-      // spyTrackUrl = jest.fn();
-      // vastTracker.trackURLs = spyTrackUrl;
       spyTrack = jest.spyOn(vastTracker, 'track');
     });
 

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -13,8 +13,6 @@ describe('VASTTracker', function () {
     let spyTrack;
     let adTrackingUrls;
     let ad;
-    let spyAdError;
-    let isCustomCode;
     const expectedMacros = {
       ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
       UNIVERSALADID: 'sample-registry%20000123',
@@ -30,7 +28,6 @@ describe('VASTTracker', function () {
       spyEmitter = jest.spyOn(vastTracker, 'emit');
       spyTrackUrl = jest.spyOn(vastTracker, 'trackURLs');
       spyTrack = jest.spyOn(vastTracker, 'track');
-      spyAdError = jest.spyOn(vastTracker, 'error');
     });
 
     describe('#click', () => {
@@ -286,31 +283,24 @@ describe('VASTTracker', function () {
       });
     });
     describe('#error', () => {
-      isCustomCode = false;
-      beforeEach(() => {
+      let isCustomCode = false;
+      it('should be called with the right arguments', () => {
         vastTracker.error();
-      });
-      it('should have emitted an ad Error and called trackUrl ', () => {
         expect(spyTrackUrl).toHaveBeenCalledWith(
           ['http://example.com/error_[ERRORCODE]'],
           expect.objectContaining(expectedMacros),
-          expect.objectContaining({ isCustomCode })
+          { isCustomCode: false }
         );
-        expect(spyTrackUrl).toHaveBeenCalledTimes(1);
       });
     });
+
     describe('#errorWithCode', () => {
-      beforeEach(() => {
+      it('should be called with the right arguments', () => {
         vastTracker.errorWithCode();
-      });
-      isCustomCode = false;
-      it('should have called the error method', () => {
-        expect(spyAdError).toHaveBeenCalledTimes(1);
-      });
-      it('called the error method with the right arguments', () => {
-        expect(spyAdError).toHaveBeenCalledWith(
-          expect.objectContaining({ ...expectedMacros }),
-          isCustomCode
+        expect(spyTrackUrl).toHaveBeenCalledWith(
+          ['http://example.com/error_[ERRORCODE]'],
+          expect.objectContaining(expectedMacros),
+          { isCustomCode: false }
         );
       });
     });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -4,7 +4,7 @@ import { inlineTrackersParsed } from '../spec/samples/inline_trackers';
 
 const vastClient = new VASTClient();
 
-describe('VASTTracker', function() {
+describe('VASTTracker', function () {
   let vastTracker = null;
 
   describe('#linear', () => {
@@ -13,13 +13,15 @@ describe('VASTTracker', function() {
     let spyTrack;
     let adTrackingUrls;
     let ad;
+    let isCustomCode = false;
+    let spyAdError;
     const expectedMacros = {
       ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
       UNIVERSALADID: 'sample-registry%20000123',
       PODSEQUENCE: '1',
       ADSERVINGID: 'z292x16y-3d7f-6440-bd29-2ec0f153fc89',
       ADTYPE: 'video',
-      ADCATEGORIES: 'Category-A%2CCategory-B%2CCategory-C'
+      ADCATEGORIES: 'Category-A%2CCategory-B%2CCategory-C',
     };
     beforeEach(() => {
       ad = inlineTrackersParsed.ads[0];
@@ -28,6 +30,7 @@ describe('VASTTracker', function() {
       spyEmitter = jest.spyOn(vastTracker, 'emit');
       spyTrackUrl = jest.spyOn(vastTracker, 'trackURLs');
       spyTrack = jest.spyOn(vastTracker, 'track');
+      spyAdError = jest.spyOn(vastTracker, 'error');
     });
 
     describe('#click', () => {
@@ -45,7 +48,7 @@ describe('VASTTracker', function() {
           ad.creatives[0].videoClickTrackingURLTemplates,
           expect.objectContaining({
             ...expectedMacros,
-            ADPLAYHEAD: '01%3A15%3A05.250'
+            ADPLAYHEAD: '01%3A15%3A05.250',
           })
         );
       });
@@ -60,7 +63,7 @@ describe('VASTTracker', function() {
       });
       it('should have emitted minimize event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('minimize', {
-          trackingURLTemplates: adTrackingUrls.minimize
+          trackingURLTemplates: adTrackingUrls.minimize,
         });
 
         expect(spyTrackUrl).toHaveBeenCalledWith(
@@ -88,7 +91,7 @@ describe('VASTTracker', function() {
           expect.objectContaining(reasonMacro)
         );
         expect(spyEmitter).toHaveBeenCalledWith('verificationNotExecuted', {
-          trackingURLTemplates: verificationUrl
+          trackingURLTemplates: verificationUrl,
         });
       });
       it('should throw missing AdVerification vendor error', () => {
@@ -118,7 +121,7 @@ describe('VASTTracker', function() {
       });
       it('should have emitted otherAdInteraction event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('otherAdInteraction', {
-          trackingURLTemplates: adTrackingUrls.otherAdInteraction
+          trackingURLTemplates: adTrackingUrls.otherAdInteraction,
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.otherAdInteraction,
@@ -136,7 +139,7 @@ describe('VASTTracker', function() {
       });
       it('should have emitted acceptInvitation event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('acceptInvitation', {
-          trackingURLTemplates: adTrackingUrls.acceptInvitation
+          trackingURLTemplates: adTrackingUrls.acceptInvitation,
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.acceptInvitation,
@@ -154,7 +157,7 @@ describe('VASTTracker', function() {
       });
       it('should have emitted adExpand event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('adExpand', {
-          trackingURLTemplates: adTrackingUrls.adExpand
+          trackingURLTemplates: adTrackingUrls.adExpand,
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.adExpand,
@@ -172,7 +175,7 @@ describe('VASTTracker', function() {
       });
       it('should have emitted adCollapse event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('adCollapse', {
-          trackingURLTemplates: adTrackingUrls.adCollapse
+          trackingURLTemplates: adTrackingUrls.adCollapse,
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.adCollapse,
@@ -185,7 +188,7 @@ describe('VASTTracker', function() {
       beforeEach(() => {
         vastTracker.overlayViewDuration('00:00:30', {
           CONTENTPLAYHEAD: '00:00:40',
-          MEDIAPLAYHEAD: '00:00:40'
+          MEDIAPLAYHEAD: '00:00:40',
         });
       });
       it('should be defined', () => {
@@ -193,7 +196,7 @@ describe('VASTTracker', function() {
       });
       it('should have emitted adExpand event and called trackUrl', () => {
         expect(spyEmitter).toHaveBeenCalledWith('overlayViewDuration', {
-          trackingURLTemplates: adTrackingUrls.overlayViewDuration
+          trackingURLTemplates: adTrackingUrls.overlayViewDuration,
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.overlayViewDuration,
@@ -201,7 +204,7 @@ describe('VASTTracker', function() {
             ...expectedMacros,
             ADPLAYHEAD: '00%3A00%3A30',
             CONTENTPLAYHEAD: '00%3A00%3A40',
-            MEDIAPLAYHEAD: '00%3A00%3A40'
+            MEDIAPLAYHEAD: '00%3A00%3A40',
           })
         );
       });
@@ -216,7 +219,7 @@ describe('VASTTracker', function() {
         vastTracker.adCollapse();
 
         expect(spyEmitter).toHaveBeenCalledWith('notUsed', {
-          trackingURLTemplates: adTrackingUrls.notUsed
+          trackingURLTemplates: adTrackingUrls.notUsed,
         });
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.notUsed,
@@ -252,7 +255,7 @@ describe('VASTTracker', function() {
 
     describe('#trackImpression', () => {
       const macros = {
-        SERVERSIDE: '0'
+        SERVERSIDE: '0',
       };
 
       beforeEach(() => {
@@ -280,6 +283,43 @@ describe('VASTTracker', function() {
         vastTracker.trackImpression(macros);
         expect(spyTrackUrl).not.toHaveBeenCalledTimes(2);
         expect(spyTrack).not.toHaveBeenCalledTimes(2);
+      });
+    });
+    describe('#error', () => {
+      let isCustomCode = false;
+      beforeEach(() => {
+        vastTracker.error();
+      });
+      it('should be defined', () => {
+        expect(ad.errorURLTemplates).toBeDefined();
+      });
+      it('should have emitted an ad Error and called trackUrl ', () => {
+        expect(spyTrackUrl).toHaveBeenCalledWith(
+          ['http://example.com/error_[ERRORCODE]'],
+          expect.objectContaining(expectedMacros),
+          expect.objectContaining({ isCustomCode })
+        );
+        expect(spyTrackUrl).toHaveBeenCalledTimes(1);
+      });
+    });
+    describe('#errorWithCode', () => {
+      let errorCode = 404;
+      beforeEach(() => {
+        vastTracker.errorWithCode();
+      });
+      it('should be defined', () => {
+        expect(ad.errorURLTemplates).toBeDefined();
+      });
+      it('should hava called the error method', () => {
+        expect(spyAdError).toHaveBeenCalledTimes(1);
+      });
+      it('should have emitted adErrpr, called trackUrl and not emitted any other event', () => {
+        expect(spyTrackUrl).toHaveBeenCalledWith(
+          ['http://example.com/error_[ERRORCODE]'],
+          expect.objectContaining(expectedMacros),
+          expect.objectContaining({ isCustomCode })
+        );
+        expect(spyTrackUrl).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -20,7 +20,6 @@ describe('VASTTracker', function () {
       ADSERVINGID: 'z292x16y-3d7f-6440-bd29-2ec0f153fc89',
       ADTYPE: 'video',
       ADCATEGORIES: 'Category-A%2CCategory-B%2CCategory-C',
-      ADPLAYHEAD: '01%3A15%3A05.250',
     };
 
     beforeEach(() => {
@@ -45,10 +44,7 @@ describe('VASTTracker', function () {
 
         expect(spyTrackUrl).toHaveBeenCalledWith(
           ad.creatives[0].videoClickTrackingURLTemplates,
-          expect.objectContaining({
-            ...expectedMacros,
-            ADPLAYHEAD: '01%3A15%3A05.250',
-          })
+          expectedMacros
         );
       });
     });
@@ -67,7 +63,7 @@ describe('VASTTracker', function () {
 
         expect(spyTrackUrl).toHaveBeenCalledWith(
           adTrackingUrls.minimize,
-          expect.objectContaining(expectedMacros)
+          expectedMacros
         );
       });
     });

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -308,7 +308,6 @@ export class VASTTracker extends EventEmitter {
   /**
    * Tracks an impression (can be called only once).
    * @param {Object} [macros={}] - An optional Object containing macros and their values to be used and replaced in the tracking calls.
-   *
    * @emits VASTTracker#creativeView
    */
   trackImpression(macros = {}) {
@@ -322,7 +321,6 @@ export class VASTTracker extends EventEmitter {
   /**
    * Send a request to the URI provided by the VAST <Error> element.
    * @param {Object} [macros={}] - An optional Object containing macros and their values to be used and replaced in the tracking calls.
-   *
    * @param {Boolean} [isCustomCode=false] - Flag to allow custom values on error code.
    */
 
@@ -333,8 +331,7 @@ export class VASTTracker extends EventEmitter {
   /**
    * Send a request to the URI provided by the VAST <Error> element.
    * If an [ERRORCODE] macro is included, it will be substitute with errorCode.
-   * This method is deprecated
-   *
+   * @deprecated
    * @param {String} errorCode - Replaces [ERRORCODE] macro. [ERRORCODE] values are listed in the VAST specification.
    * @param {Boolean} [isCustomCode=false] - Flag to allow custom values on error code.
    */
@@ -342,7 +339,9 @@ export class VASTTracker extends EventEmitter {
   errorWithCode(errorCode, isCustomCode = false) {
     this.error({ ERRORCODE: errorCode }, isCustomCode);
     //eslint-disable-next-line
-    console.log('errorWithCode : this method is deprecated');
+    console.log(
+      'The method errorWithCode is deprecated, please use vast tracker error method instead'
+    );
   }
 
   /**

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -55,7 +55,7 @@ export class VASTTracker extends EventEmitter {
       'rewind',
       'skip',
       'closeLinear',
-      'close'
+      'close',
     ];
 
     // Duplicate the creative's trackingEvents property so we can alter it
@@ -148,7 +148,7 @@ export class VASTTracker extends EventEmitter {
     this.quartiles = {
       firstQuartile: Math.round(25 * this.assetDuration) / 100,
       midpoint: Math.round(50 * this.assetDuration) / 100,
-      thirdQuartile: Math.round(75 * this.assetDuration) / 100
+      thirdQuartile: Math.round(75 * this.assetDuration) / 100,
     };
   }
 
@@ -198,7 +198,7 @@ export class VASTTracker extends EventEmitter {
         }
         this.lastPercentage = percent;
       }
-      events.forEach(eventName => {
+      events.forEach((eventName) => {
         this.track(eventName, { macros, once: true });
       });
 
@@ -321,21 +321,29 @@ export class VASTTracker extends EventEmitter {
 
   /**
    * Send a request to the URI provided by the VAST <Error> element.
+   * @param {Object} [macros={}] - An optional Object containing macros and their values to be used and replaced in the tracking calls.
+   *
+   * @param {Boolean} [isCustomCode=false] - Flag to allow custom values on error code.
+   */
+
+  error(macros = {}, isCustomCode = false) {
+    this.trackURLs(this.ad.errorURLTemplates, macros, { isCustomCode });
+  }
+
+  /**
+   * Send a request to the URI provided by the VAST <Error> element.
    * If an [ERRORCODE] macro is included, it will be substitute with errorCode.
+   * This method is deprecated
    *
    * @param {String} errorCode - Replaces [ERRORCODE] macro. [ERRORCODE] values are listed in the VAST specification.
    * @param {Boolean} [isCustomCode=false] - Flag to allow custom values on error code.
    */
+
   errorWithCode(errorCode, isCustomCode = false) {
-    this.trackURLs(
-      this.ad.errorURLTemplates,
-      { ERRORCODE: errorCode },
-      { isCustomCode }
-    );
+    this.error({ ERRORCODE: errorCode }, isCustomCode);
+    console.log('errorWithCode : this method is deprecated');
   }
-  error(macros = {}) {
-    this.trackURLs(this.ad.errorURLTemplates, { macros });
-  }
+
   /**
    * Must be called when the user watched the linear creative until its end.
    * Calls the complete tracking URLs.
@@ -445,7 +453,7 @@ export class VASTTracker extends EventEmitter {
     }
 
     const vendorVerification = this.ad.adVerifications.find(
-      verifications => verifications.vendor === vendor
+      (verifications) => verifications.vendor === vendor
     );
 
     if (!vendorVerification) {
@@ -459,7 +467,7 @@ export class VASTTracker extends EventEmitter {
       const verifsNotExecuted = vendorTracking.verificationNotExecuted;
       this.trackURLs(verifsNotExecuted, macros);
       this.emit('verificationNotExecuted', {
-        trackingURLTemplates: verifsNotExecuted
+        trackingURLTemplates: verifsNotExecuted,
       });
     }
   }
@@ -618,9 +626,9 @@ export class VASTTracker extends EventEmitter {
       this.creative.universalAdId.idRegistry &&
       this.creative.universalAdId.value
     ) {
-      macros['UNIVERSALADID'] = `${this.creative.universalAdId.idRegistry} ${
-        this.creative.universalAdId.value
-      }`;
+      macros[
+        'UNIVERSALADID'
+      ] = `${this.creative.universalAdId.idRegistry} ${this.creative.universalAdId.value}`;
     }
 
     if (this.ad) {
@@ -635,7 +643,7 @@ export class VASTTracker extends EventEmitter {
       }
       if (this.ad.categories && this.ad.categories.length) {
         macros['ADCATEGORIES'] = this.ad.categories
-          .map(categorie => categorie.value)
+          .map((categorie) => categorie.value)
           .join(',');
       }
       if (this.ad.blockedAdCategories && this.ad.blockedAdCategories.length) {

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -341,6 +341,7 @@ export class VASTTracker extends EventEmitter {
 
   errorWithCode(errorCode, isCustomCode = false) {
     this.error({ ERRORCODE: errorCode }, isCustomCode);
+    //eslint-disable-next-line
     console.log('errorWithCode : this method is deprecated');
   }
 

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -333,7 +333,9 @@ export class VASTTracker extends EventEmitter {
       { isCustomCode }
     );
   }
-
+  error(macros = {}) {
+    this.trackURLs(this.ad.errorURLTemplates, { macros });
+  }
   /**
    * Must be called when the user watched the linear creative until its end.
    * Calls the complete tracking URLs.

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -650,7 +650,6 @@ export class VASTTracker extends EventEmitter {
         givenMacros['BLOCKEDADCATEGORIES'] = this.ad.blockedAdCategories;
       }
     }
-
     util.track(URLTemplates, givenMacros, options);
   }
 

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -323,7 +323,6 @@ export class VASTTracker extends EventEmitter {
    * @param {Object} [macros={}] - An optional Object containing macros and their values to be used and replaced in the tracking calls.
    * @param {Boolean} [isCustomCode=false] - Flag to allow custom values on error code.
    */
-
   error(macros = {}, isCustomCode = false) {
     this.trackURLs(this.ad.errorURLTemplates, macros, { isCustomCode });
   }
@@ -335,7 +334,6 @@ export class VASTTracker extends EventEmitter {
    * @param {String} errorCode - Replaces [ERRORCODE] macro. [ERRORCODE] values are listed in the VAST specification.
    * @param {Boolean} [isCustomCode=false] - Flag to allow custom values on error code.
    */
-
   errorWithCode(errorCode, isCustomCode = false) {
     this.error({ ERRORCODE: errorCode }, isCustomCode);
     //eslint-disable-next-line

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -650,6 +650,7 @@ export class VASTTracker extends EventEmitter {
         givenMacros['BLOCKEDADCATEGORIES'] = this.ad.blockedAdCategories;
       }
     }
+
     util.track(URLTemplates, givenMacros, options);
   }
 

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -605,6 +605,8 @@ export class VASTTracker extends EventEmitter {
    * @param {Object} [options={}] - An optional Object of options to be used in the tracking calls.
    */
   trackURLs(URLTemplates, macros = {}, options = {}) {
+    //Avoid mutating the object received in parameters.
+    const givenMacros = { ...macros };
     if (this.linear) {
       if (
         this.creative &&
@@ -612,10 +614,10 @@ export class VASTTracker extends EventEmitter {
         this.creative.mediaFiles[0] &&
         this.creative.mediaFiles[0].fileURL
       ) {
-        macros['ASSETURI'] = this.creative.mediaFiles[0].fileURL;
+        givenMacros['ASSETURI'] = this.creative.mediaFiles[0].fileURL;
       }
       if (this.progress) {
-        macros['ADPLAYHEAD'] = this.progressFormatted();
+        givenMacros['ADPLAYHEAD'] = this.progressFormatted();
       }
     }
     if (
@@ -624,32 +626,32 @@ export class VASTTracker extends EventEmitter {
       this.creative.universalAdId.idRegistry &&
       this.creative.universalAdId.value
     ) {
-      macros[
+      givenMacros[
         'UNIVERSALADID'
       ] = `${this.creative.universalAdId.idRegistry} ${this.creative.universalAdId.value}`;
     }
 
     if (this.ad) {
       if (this.ad.sequence) {
-        macros['PODSEQUENCE'] = this.ad.sequence;
+        givenMacros['PODSEQUENCE'] = this.ad.sequence;
       }
       if (this.ad.adType) {
-        macros['ADTYPE'] = this.ad.adType;
+        givenMacros['ADTYPE'] = this.ad.adType;
       }
       if (this.ad.adServingId) {
-        macros['ADSERVINGID'] = this.ad.adServingId;
+        givenMacros['ADSERVINGID'] = this.ad.adServingId;
       }
       if (this.ad.categories && this.ad.categories.length) {
-        macros['ADCATEGORIES'] = this.ad.categories
+        givenMacros['ADCATEGORIES'] = this.ad.categories
           .map((categorie) => categorie.value)
           .join(',');
       }
       if (this.ad.blockedAdCategories && this.ad.blockedAdCategories.length) {
-        macros['BLOCKEDADCATEGORIES'] = this.ad.blockedAdCategories;
+        givenMacros['BLOCKEDADCATEGORIES'] = this.ad.blockedAdCategories;
       }
     }
 
-    util.track(URLTemplates, macros, options);
+    util.track(URLTemplates, givenMacros, options);
   }
 
   /**

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -287,11 +287,11 @@ describe('VASTTracker', function () {
 
       describe('#errorWithCode', () => {
         before(() => {
-          this.Tracker.error(
+          util.track = function (URLTemplates, variables, options) {
             _eventsSent.push(
-              this.resolveURLTemplates(URLTemplates, macros, options)
-            )
-          );
+              this.resolveURLTemplates(URLTemplates, variables, options)
+            );
+          };
         });
         beforeEach(() => {
           _eventsSent = [];

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -285,13 +285,42 @@ describe('VASTTracker', function() {
         });
       });
 
-      describe('#errorWithCode', () => {
+      describe('#error', () => {
         before(() => {
-          util.track = function(URLTemplates, variables, options) {
+          util.track = function(URLTemplates, macros, options) {
             _eventsSent.push(
-              this.resolveURLTemplates(URLTemplates, variables, options)
+              this.resolveURLTemplates(URLTemplates, macros, options)
             );
           };
+        });
+        beforeEach(() => {
+          _eventsSent = [];
+        });
+
+        it('should have called error urls with right code', () => {
+          this.Tracker.error(405);
+          _eventsSent[0].should.eql([
+            'http://example.com/wrapperA-error',
+            'http://example.com/wrapperB-error',
+            'http://example.com/error_405'
+          ]);
+        });
+
+        it('should have called error urls with 900 if unknown code', () => {
+          this.Tracker.error(10001);
+          _eventsSent[0].should.eql([
+            'http://example.com/wrapperA-error',
+            'http://example.com/wrapperB-error',
+            'http://example.com/error_900'
+          ]);
+        });
+
+      describe('#errorWithCode', () => {
+        before(() => {
+          this.Tracker.error(
+            _eventsSent.push(
+              this.resolveURLTemplates(URLTemplates, macros, options)
+            ));;
         });
         beforeEach(() => {
           _eventsSent = [];

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -11,15 +11,15 @@ const now = new Date();
 const vastParser = new VASTParser();
 const vastClient = new VASTClient();
 const options = {
-  urlhandler: nodeURLHandler
+  urlhandler: nodeURLHandler,
 };
 
-const urlfor = relpath =>
+const urlfor = (relpath) =>
   `file:///${path
     .resolve(path.dirname(module.filename), 'vastfiles', relpath)
     .replace(/\\/g, '/')}`;
 
-describe('VASTTracker', function() {
+describe('VASTTracker', function () {
   before(() => {
     this.clock = sinon.useFakeTimers(now.getTime());
   });
@@ -28,21 +28,21 @@ describe('VASTTracker', function() {
     this.clock.restore();
   });
 
-  describe('#constructor', function() {
+  describe('#constructor', function () {
     this.Tracker = null;
     let _eventsSent = [];
     this.templateFilterCalls = [];
     this.response = {};
 
-    before(done => {
-      vastParser.addURLTemplateFilter(url => {
+    before((done) => {
+      vastParser.addURLTemplateFilter((url) => {
         this.templateFilterCalls.push(url);
         return url;
       });
 
       vastParser
         .getAndParseVAST(urlfor('wrapper-a.xml'), options)
-        .then(response => {
+        .then((response) => {
           this.response = response;
           done();
         });
@@ -57,11 +57,11 @@ describe('VASTTracker', function() {
         // Init tracker
         const ad = this.response.ads[0];
         const creative = ad.creatives.filter(
-          creative => creative.id === 'id130984'
+          (creative) => creative.id === 'id130984'
         )[0];
         this.Tracker = new VASTTracker(vastClient, ad, creative);
         // Mock emit
-        this.Tracker.emit = event => {
+        this.Tracker.emit = (event) => {
           _eventsSent.push(event);
         };
       });
@@ -83,7 +83,7 @@ describe('VASTTracker', function() {
       });
 
       describe('#setProgress', () => {
-        beforeEach(done => {
+        beforeEach((done) => {
           _eventsSent = [];
           done();
         });
@@ -131,7 +131,7 @@ describe('VASTTracker', function() {
       });
 
       describe('#setMuted', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
           this.Tracker.trackingEvents['mute'] = 'http://example.com/muted';
           this.Tracker.trackingEvents['unmute'] = 'http://example.com/muted';
@@ -165,7 +165,7 @@ describe('VASTTracker', function() {
       });
 
       describe('#setPaused', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
           this.Tracker.setPaused(true);
           done();
@@ -197,7 +197,7 @@ describe('VASTTracker', function() {
       });
 
       describe('#setFullscreen', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
           this.Tracker.trackingEvents['fullscreen'] =
             'http://example.com/fullscreen';
@@ -233,7 +233,7 @@ describe('VASTTracker', function() {
       });
 
       describe('#setExpand', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
           this.Tracker.trackingEvents['expand'] = 'http://example.com/expand';
           this.Tracker.trackingEvents[
@@ -285,42 +285,13 @@ describe('VASTTracker', function() {
         });
       });
 
-      describe('#error', () => {
-        before(() => {
-          util.track = function(URLTemplates, macros, options) {
-            _eventsSent.push(
-              this.resolveURLTemplates(URLTemplates, macros, options)
-            );
-          };
-        });
-        beforeEach(() => {
-          _eventsSent = [];
-        });
-
-        it('should have called error urls with right code', () => {
-          this.Tracker.error(405);
-          _eventsSent[0].should.eql([
-            'http://example.com/wrapperA-error',
-            'http://example.com/wrapperB-error',
-            'http://example.com/error_405'
-          ]);
-        });
-
-        it('should have called error urls with 900 if unknown code', () => {
-          this.Tracker.error(10001);
-          _eventsSent[0].should.eql([
-            'http://example.com/wrapperA-error',
-            'http://example.com/wrapperB-error',
-            'http://example.com/error_900'
-          ]);
-        });
-
       describe('#errorWithCode', () => {
         before(() => {
           this.Tracker.error(
             _eventsSent.push(
               this.resolveURLTemplates(URLTemplates, macros, options)
-            ));;
+            )
+          );
         });
         beforeEach(() => {
           _eventsSent = [];
@@ -331,7 +302,7 @@ describe('VASTTracker', function() {
           _eventsSent[0].should.eql([
             'http://example.com/wrapperA-error',
             'http://example.com/wrapperB-error',
-            'http://example.com/error_405'
+            'http://example.com/error_405',
           ]);
         });
 
@@ -340,7 +311,7 @@ describe('VASTTracker', function() {
           _eventsSent[0].should.eql([
             'http://example.com/wrapperA-error',
             'http://example.com/wrapperB-error',
-            'http://example.com/error_900'
+            'http://example.com/error_900',
           ]);
         });
 
@@ -349,13 +320,13 @@ describe('VASTTracker', function() {
           _eventsSent[0].should.eql([
             'http://example.com/wrapperA-error',
             'http://example.com/wrapperB-error',
-            'http://example.com/error_10001'
+            'http://example.com/error_10001',
           ]);
         });
       });
 
       describe('#complete', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
           this.Tracker.complete();
           done();
@@ -367,8 +338,8 @@ describe('VASTTracker', function() {
             [
               'http://example.com/linear-complete',
               'http://example.com/wrapperB-linear-complete',
-              'http://example.com/wrapperA-linear-complete'
-            ]
+              'http://example.com/wrapperA-linear-complete',
+            ],
           ]);
         });
 
@@ -380,14 +351,14 @@ describe('VASTTracker', function() {
             [
               'http://example.com/linear-complete',
               'http://example.com/wrapperB-linear-complete',
-              'http://example.com/wrapperA-linear-complete'
-            ]
+              'http://example.com/wrapperA-linear-complete',
+            ],
           ]);
         });
       });
 
       describe('#close', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
           this.Tracker.close();
           done();
@@ -396,26 +367,26 @@ describe('VASTTracker', function() {
         it('should have sent close event and urls VAST 2.0', () => {
           _eventsSent.should.eql([
             'close',
-            ['http://example.com/linear-close']
+            ['http://example.com/linear-close'],
           ]);
         });
 
         it('should have sent closeLinear event and urls VAST 3.0', () => {
           _eventsSent = [];
           this.Tracker.trackingEvents['closeLinear'] = [
-            'http://example.com/closelinear'
+            'http://example.com/closelinear',
           ];
           delete this.Tracker.trackingEvents['close'];
           this.Tracker.close();
           _eventsSent.should.eql([
             'closeLinear',
-            ['http://example.com/closelinear']
+            ['http://example.com/closelinear'],
           ]);
         });
       });
 
       describe('#skip', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
           this.Tracker.skip();
           done();
@@ -436,9 +407,9 @@ describe('VASTTracker', function() {
       });
 
       describe('#click', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
-          util.track = function(URLTemplates, variables) {
+          util.track = function (URLTemplates, variables) {
             _eventsSent.push(this.resolveURLTemplates(URLTemplates, variables));
           };
           this.Tracker.click();
@@ -455,7 +426,7 @@ describe('VASTTracker', function() {
             'http://example.com/wrapperB-linear-clicktracking',
             'http://example.com/wrapperA-linear-clicktracking1',
             'http://example.com/wrapperA-linear-clicktracking2',
-            'http://example.com/wrapperA-linear-clicktracking3'
+            'http://example.com/wrapperA-linear-clicktracking3',
           ]);
         });
 
@@ -470,17 +441,17 @@ describe('VASTTracker', function() {
         // Init tracker
         const ad = this.response.ads[0];
         const creative = ad.creatives.filter(
-          creative => creative.id === 'id130984'
+          (creative) => creative.id === 'id130984'
         )[0];
         this.Tracker = new VASTTracker(vastClient, ad, creative);
         // Mock emit
-        this.Tracker.emit = event => {
+        this.Tracker.emit = (event) => {
           _eventsSent.push(event);
         };
       });
 
       describe('#setProgress seek ads IOS', () => {
-        beforeEach(done => {
+        beforeEach((done) => {
           _eventsSent = [];
           done();
         });
@@ -500,7 +471,7 @@ describe('VASTTracker', function() {
         // Init tracker
         const ad = this.response.ads[0];
         const creative = ad.creatives.filter(
-          creative => creative.id === 'id130985'
+          (creative) => creative.id === 'id130985'
         )[0];
         const variation = creative.variations[0];
         this.Tracker = new VASTTracker(vastClient, ad, creative, variation);
@@ -511,9 +482,9 @@ describe('VASTTracker', function() {
       });
 
       describe('#click', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
-          util.track = function(URLTemplates, variables) {
+          util.track = function (URLTemplates, variables) {
             _eventsSent.push(this.resolveURLTemplates(URLTemplates, variables));
           };
           this.Tracker.click();
@@ -528,14 +499,14 @@ describe('VASTTracker', function() {
             'http://example.com/companion1-clicktracking-first',
             'http://example.com/companion1-clicktracking-second',
             'http://example.com/wrapperB-companion1-click-tracking',
-            'http://example.com/wrapperA-companion1-click-tracking'
+            'http://example.com/wrapperA-companion1-click-tracking',
           ]);
         });
 
         it('should have sent clickthrough event with clickThrough url', () => {
           _eventsSent[1].event.should.eql('clickthrough');
           _eventsSent[1].args.should.eql([
-            'http://example.com/companion1-clickthrough'
+            'http://example.com/companion1-clickthrough',
           ]);
         });
       });
@@ -546,7 +517,7 @@ describe('VASTTracker', function() {
         // Init tracker
         const ad = this.response.ads[0];
         const creative = ad.creatives.filter(
-          creative => creative.id === 'id130986'
+          (creative) => creative.id === 'id130986'
         )[0];
         const variation = creative.variations[0];
         this.Tracker = new VASTTracker(vastClient, ad, creative, variation);
@@ -561,9 +532,9 @@ describe('VASTTracker', function() {
       });
 
       describe('#click', () => {
-        before(done => {
+        before((done) => {
           _eventsSent = [];
-          util.track = function(URLTemplates, variables) {
+          util.track = function (URLTemplates, variables) {
             _eventsSent.push(this.resolveURLTemplates(URLTemplates, variables));
           };
           this.Tracker.click();
@@ -576,14 +547,14 @@ describe('VASTTracker', function() {
           );
           _eventsSent[0].should.eql([
             'http://example.com/nonlinear-clicktracking-1',
-            'http://example.com/nonlinear-clicktracking-2'
+            'http://example.com/nonlinear-clicktracking-2',
           ]);
         });
 
         it('should have sent clickthrough event with clickThrough url', () => {
           _eventsSent[1].event.should.eql('clickthrough');
           _eventsSent[1].args.should.eql([
-            'http://example.com/nonlinear-clickthrough'
+            'http://example.com/nonlinear-clickthrough',
           ]);
         });
       });


### PR DESCRIPTION
### Description

Right now, vastTracker.errorWithCode only take the error code and only replace the [ERRORCODE] macro, we need to improve the function to also handle all other macros.

The ida is to create vastTracker.error() and take a macro object as for all other methods, and deprecate the other method.


### Type
- [ ] Breaking change
- [X] Enhancement
- [x] Fix
- [ ] Documentation
- [ ] Tooling
