### PR TITLE
Issue-376

### DIFF
--- a/docs/api/class-reference.md
+++ b/docs/api/class-reference.md
@@ -183,7 +183,7 @@ This object represents a generic Creative. It's used as a parent object for more
 
 ## UniversalAdId<a name="universaladid"></a>
 
-- `idRegistry: String|unknown`
+- `idRegistry: String|'unknown'` A string used to identify the URL for the registry website where the unique creative ID is cataloged. Default value is “unknown”.
 - `value: any`
 
 ## AdVerification<a name="ad-verification"></a>

--- a/docs/api/class-reference.md
+++ b/docs/api/class-reference.md
@@ -39,7 +39,7 @@ This object represents a generic Creative. It's used as a parent object for more
 - `adId: String|null`
 - `sequence: Number|null`
 - `apiFramework: String|null`
-- `universalAdId: Object|null`
+- `universalAdIds: Array<Object>` [go to object](#universaladid)
 - `creativeExtensions: Array<Object>` [go to object](#extension)
 
 ## CreativeLinear *extends* Creative<a name="creative-linear"></a>
@@ -180,6 +180,11 @@ This object represents a generic Creative. It's used as a parent object for more
 - `value: any`
 - `attributes: Object`
 - `children: Array<Extension>`
+
+## UniversalAdId<a name="universaladid"></a>
+
+- `idRegistry: String|unknown`
+- `value: any`
 
 ## AdVerification<a name="ad-verification"></a>
 

--- a/spec/creatives_parser.spec.js
+++ b/spec/creatives_parser.spec.js
@@ -23,8 +23,10 @@ describe('CreativesParser', function() {
       const creative = parsedCreatives[0];
       expect(creative.id).toEqual('id130984');
       expect(creative.adId).toEqual('adId345690');
-      expect(creative.universalAdIds[0].idRegistry).toEqual('daily-motion-L');
+      expect(creative.universalAdIds[0].idRegistry).toEqual('daily-motion-L1');
       expect(creative.universalAdIds[0].value).toEqual('Linear-12345');
+      expect(creative.universalAdIds[1].idRegistry).toEqual('daily-motion-L2');
+      expect(creative.universalAdIds[1].value).toEqual('Linear-5678');
       expect(creative.type).toEqual('linear');
       expect(creative.mediaFiles.length).toEqual(2);
     });

--- a/spec/creatives_parser.spec.js
+++ b/spec/creatives_parser.spec.js
@@ -23,8 +23,8 @@ describe('CreativesParser', function() {
       const creative = parsedCreatives[0];
       expect(creative.id).toEqual('id130984');
       expect(creative.adId).toEqual('adId345690');
-      expect(creative.universalAdId.idRegistry).toEqual('daily-motion-L');
-      expect(creative.universalAdId.value).toEqual('Linear-12345');
+      expect(creative.universalAdIds[0].idRegistry).toEqual('daily-motion-L');
+      expect(creative.universalAdIds[0].value).toEqual('Linear-12345');
       expect(creative.type).toEqual('linear');
       expect(creative.mediaFiles.length).toEqual(2);
     });
@@ -33,7 +33,7 @@ describe('CreativesParser', function() {
       const creative = parsedCreatives[1];
       expect(creative.id).toEqual('id130985');
       expect(creative.adId).toEqual('adId345691');
-      expect(creative.universalAdId).toEqual(undefined);
+      expect(creative.universalAdIds).toEqual([]);
       expect(creative.type).toEqual('companion');
       expect(creative.variations.length).toEqual(3);
     });
@@ -42,8 +42,8 @@ describe('CreativesParser', function() {
       const creative = parsedCreatives[2];
       expect(creative.id).toEqual('id130986');
       expect(creative.adId).toEqual(null);
-      expect(creative.universalAdId.idRegistry).toEqual('daily-motion-NL');
-      expect(creative.universalAdId.value).toEqual('NonLinear-12345');
+      expect(creative.universalAdIds[0].idRegistry).toEqual('daily-motion-NL');
+      expect(creative.universalAdIds[0].value).toEqual('NonLinear-12345');
       expect(creative.type).toEqual('nonlinear');
       expect(creative.variations.length).toEqual(1);
     });

--- a/spec/samples/creatives.js
+++ b/spec/samples/creatives.js
@@ -1,6 +1,7 @@
 export const creatives = `<Creatives>
   <Creative id="id130984" adId="adId345690" sequence="1" >
-    <UniversalAdId idRegistry="daily-motion-L">Linear-12345</UniversalAdId>
+    <UniversalAdId idRegistry="daily-motion-L1">Linear-12345</UniversalAdId>
+    <UniversalAdId idRegistry="daily-motion-L2">Linear-5678</UniversalAdId>
     <CreativeExtensions>
       <CreativeExtension type="creativeExt1">
         <CreativeExecution model="CPM" currency="USD" source="someone">

--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -170,10 +170,16 @@ export const inlineTrackersParsed = {
             ],
             notUsed: ['http://example.com/linear-notUsed&assetURI=[ASSETURI]']
           },
-          universalAdId: {
-            idRegistry: 'sample-registry',
-            value: '000123'
-          }
+          universalAdIds: [
+            {
+              idRegistry: 'sample-registry',
+              value: '000123'
+            },
+            {
+              idRegistry: 'sample-registry-2',
+              value: '000456'
+            }
+          ]
         }
       ],
       extensions: [

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -15,7 +15,7 @@ describe('VASTTracker', function() {
     let ad;
     const expectedMacros = {
       ASSETURI: 'http%3A%2F%2Fexample.com%2Flinear-asset.mp4',
-      UNIVERSALADID: 'sample-registry%20000123',
+      UNIVERSALADID: 'sample-registry%20000123%2Csample-registry-2%20000456',
       PODSEQUENCE: '1',
       ADSERVINGID: 'z292x16y-3d7f-6440-bd29-2ec0f153fc89',
       ADTYPE: 'video',

--- a/src/creative/creative.js
+++ b/src/creative/creative.js
@@ -4,7 +4,7 @@ export function createCreative(creativeAttributes = {}) {
     adId: creativeAttributes.adId || null,
     sequence: creativeAttributes.sequence || null,
     apiFramework: creativeAttributes.apiFramework || null,
-    universalAdId: { value: null, idRegistry: 'unknown' },
+    universalAdIds: [],
     creativeExtensions: []
   };
 }

--- a/src/parser/creatives_parser.js
+++ b/src/parser/creatives_parser.js
@@ -20,18 +20,19 @@ export function parseCreatives(creativeNodes) {
       apiFramework: creativeElement.getAttribute('apiFramework') || null
     };
 
-    let universalAdId;
-    const universalAdIdElement = parserUtils.childByName(
+    const universalAdIds = [];
+    const universalAdIdElements = parserUtils.childrenByName(
       creativeElement,
       'UniversalAdId'
     );
-    if (universalAdIdElement) {
-      universalAdId = {
+    universalAdIdElements.forEach(universalAdIdElement => {
+      const universalAdId = {
         idRegistry:
           universalAdIdElement.getAttribute('idRegistry') || 'unknown',
         value: parserUtils.parseNodeText(universalAdIdElement)
       };
-    }
+      universalAdIds.push(universalAdId);
+    })
 
     let creativeExtensions;
     const creativeExtensionsElement = parserUtils.childByName(
@@ -74,8 +75,8 @@ export function parseCreatives(creativeNodes) {
       }
 
       if (parsedCreative) {
-        if (universalAdId) {
-          parsedCreative.universalAdId = universalAdId;
+        if (universalAdIds) {
+          parsedCreative.universalAdIds = universalAdIds;
         }
 
         if (creativeExtensions) {

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -612,13 +612,12 @@ export class VASTTracker extends EventEmitter {
     }
     if (
       this.creative &&
-      this.creative.universalAdId &&
-      this.creative.universalAdId.idRegistry &&
-      this.creative.universalAdId.value
+      this.creative.universalAdIds &&
+      this.creative.universalAdIds.length
     ) {
-      macros['UNIVERSALADID'] = `${this.creative.universalAdId.idRegistry} ${
-        this.creative.universalAdId.value
-      }`;
+      macros['UNIVERSALADID'] = this.creative.universalAdIds
+        .map(universalAdId => universalAdId.idRegistry.concat(' ', universalAdId.value))
+        .join(',');
     }
 
     if (this.ad) {
@@ -633,7 +632,7 @@ export class VASTTracker extends EventEmitter {
       }
       if (this.ad.categories && this.ad.categories.length) {
         macros['ADCATEGORIES'] = this.ad.categories
-          .map(categorie => categorie.value)
+          .map(category => category.value)
           .join(',');
       }
       if (this.ad.blockedAdCategories && this.ad.blockedAdCategories.length) {

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -610,11 +610,7 @@ export class VASTTracker extends EventEmitter {
         macros['ADPLAYHEAD'] = this.progressFormatted();
       }
     }
-    if (
-      this.creative &&
-      this.creative.universalAdIds &&
-      this.creative.universalAdIds.length
-    ) {
+    if (this.creative?.universalAdIds?.length) {
       macros['UNIVERSALADID'] = this.creative.universalAdIds
         .map(universalAdId => universalAdId.idRegistry.concat(' ', universalAdId.value))
         .join(',');

--- a/test/vast_parser.js
+++ b/test/vast_parser.js
@@ -259,8 +259,8 @@ describe('VASTParser', function() {
         });
 
         it('should have a universal ad id', () => {
-          linear.universalAdId.idRegistry.should.equal('daily-motion-L');
-          linear.universalAdId.value.should.equal('Linear-12345');
+          linear.universalAdIds[0].idRegistry.should.equal('daily-motion-L1');
+          linear.universalAdIds[0].value.should.equal('Linear-12345');
         });
 
         it('should have creativeExtensions of length 3', () => {
@@ -547,8 +547,8 @@ describe('VASTParser', function() {
         });
 
         it('should have a UniversalAdId', () => {
-          should.equal(nonlinears.universalAdId.idRegistry, 'daily-motion-NL');
-          should.equal(nonlinears.universalAdId.value, 'NonLinear-12345');
+          should.equal(nonlinears.universalAdIds[0].idRegistry, 'daily-motion-NL');
+          should.equal(nonlinears.universalAdIds[0].value, 'NonLinear-12345');
         });
 
         it('should have 1 variation', () => {
@@ -743,9 +743,9 @@ describe('VASTParser', function() {
           linear.duration.should.equal(30);
         });
 
-        it('should have a UniversalAdId with value=unknown and idRegistry=null', () => {
-          should.equal(linear.universalAdId.value, 'Linear-id873421');
-          should.equal(linear.universalAdId.idRegistry, 'unknown');
+        it('should have a UniversalAdIds[0] with value=unknown and idRegistry=null', () => {
+          should.equal(linear.universalAdIds[0].value, 'Linear-id873421');
+          should.equal(linear.universalAdIds[0].idRegistry, 'unknown');
         });
 
         it('should have wrapper clickthrough URL', () => {

--- a/test/vastfiles/sample.xml
+++ b/test/vastfiles/sample.xml
@@ -41,7 +41,8 @@
       </AdVerifications>
       <Creatives>
         <Creative id="id130984" adId="adId345690" sequence="1">
-          <UniversalAdId idRegistry="daily-motion-L">Linear-12345</UniversalAdId>
+          <UniversalAdId idRegistry="daily-motion-L1">Linear-12345</UniversalAdId>
+          <UniversalAdId idRegistry="daily-motion-L2">Linear-5678</UniversalAdId>
           <CreativeExtensions>
             <CreativeExtension type="creativeExt1">
               <CreativeExecution model="CPM" currency="USD" source="someone">


### PR DESCRIPTION
Updated UniversalAdIds for multiple UniversalAdId nodes

### Description

[VAST-Client] Allow parsing of multiple UniversalAdID

### Issue

https://github.com/dailymotion/vast-client-js/issues/376

### Type
- [x] Breaking change
- [x] Enhancement
- [ ] Fix
- [x] Documentation
- [ ] Tooling
