### PR TITLE
VastTracker : fix error caused by rollup config when Node.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import resolve from '@rollup/plugin-node-resolve';
 const babelPlugin = babel({
   babelrc: false,
   presets: [['@babel/preset-env', { modules: false }]],
-  exclude: ['node_modules/**']
+  exclude: ['node_modules/**'],
 });
 
 function onwarn(warning) {
@@ -37,9 +37,9 @@ const browserConfig = {
   output: {
     name: 'VAST',
     format: 'umd',
-    file: 'dist/vast-client.js'
+    file: 'dist/vast-client.js',
   },
-  plugins: [babelPlugin]
+  plugins: [babelPlugin],
 };
 
 const browserScriptConfig = {
@@ -47,27 +47,32 @@ const browserScriptConfig = {
   output: {
     name: 'VAST',
     format: 'iife',
-    file: 'dist/vast-client-browser.js'
+    file: 'dist/vast-client-browser.js',
   },
-  plugins: [babelPlugin]
+  plugins: [babelPlugin],
 };
 
 const nodeConfig = {
   input: 'src/index.js',
   output: {
     format: 'cjs',
-    file: 'dist/vast-client-node.js'
+    file: 'dist/vast-client-node.js',
   },
   plugins: [
     alias({
-      './urlhandlers/mock_node_url_handler': './urlhandlers/node_url_handler'
+      entries: [
+        {
+          './urlhandlers/mock_node_url_handler':
+            './urlhandlers/node_url_handler',
+        },
+      ],
     }),
     resolve({
-      preferBuiltins: true
+      preferBuiltins: true,
     }),
-    babelPlugin
+    babelPlugin,
   ],
-  onwarn
+  onwarn,
 };
 
 export default [
@@ -79,5 +84,5 @@ export default [
   nodeConfig,
   minify(nodeConfig),
 
-  minify(browserScriptConfig)
+  minify(browserScriptConfig),
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -62,8 +62,8 @@ const nodeConfig = {
     alias({
       entries: [
         {
-          './urlhandlers/mock_node_url_handler':
-            './urlhandlers/node_url_handler',
+          find: './urlhandlers/mock_node_url_handler',
+          replacement: './urlhandlers/node_url_handler',
         },
       ],
     }),


### PR DESCRIPTION
### Description

Updated rollup config for Node.js. An error was automatically sent to users using Vast-Client with Node.

### Issue

[Issue Link](https://github.com/dailymotion/vast-client-js/issues/372) 

### Type
- [ ] Breaking change
- [ ] Enhancement
- [X] Fix
- [ ] Documentation
- [ ] Tooling
