### PR TITLE
[parser] Add bitrate estimation from VAST requests

### DIFF
--- a/docs/api/vast-parser.md
+++ b/docs/api/vast-parser.md
@@ -334,7 +334,7 @@ vastParser.parseVAST(vastXml, options)
 
 ### getEstimatedBitrate()
 
-Returns the average of the estimated bitrates in bits by secondes.
+Returns the average of the estimated bitrates in kilo bit per secondes.
 
 #### Example
 
@@ -346,7 +346,7 @@ const options = {
 vastParser.parseVAST(vastXml, options)
   .then(res => {
     vastParser.getEstimatedBitrate()
-    // returns 40 000
+    // returns 40
   })
   .catch(err => {
     // Deal with the error

--- a/docs/api/vast-parser.md
+++ b/docs/api/vast-parser.md
@@ -295,8 +295,8 @@ Returns a `Promise` which either resolves with the fully parsed `VASTResponse` o
   - `urlhandler: URLHandler` - Fulfills the same purpose as `urlHandler`, which is the preferred parameter to use
   - `allowMultipleAds: Boolean` - A boolean value that identifies whether multiple ads are allowed in the requested VAST response. This will override any value of allowMultipleAds attribute set in the VAST
   - `followAdditionalWrappers: Boolean` - A boolean value that identifies whether subsequent Wrappers after a requested VAST response is allowed. This will override any value of followAdditionalWrappers attribute set in the VAST
-  - `requestDuration: Number` - The fetching time of the XML. Provide it with byteLength to have a more accurate estimated bitrate.
-  - `byteLength: Number`- The size of the request. Provide it with requestDuration to have a more accurate estimated bitrate.
+  - `requestDuration: Number` - The fetching time of the XML in ms. Provide it with byteLength to have a more accurate estimated bitrate.
+  - `byteLength: Number`- The size of the request in bytes. Provide it with requestDuration to have a more accurate estimated bitrate.
 
 #### Events emitted
 
@@ -341,7 +341,7 @@ Returns the average of the estimated bitrates in kilo bit per secondes.
 ```Javascript
 const options = {
   requestDuration: 200,
-  byteLength 1000,
+  byteLength: 1000,
 }
 vastParser.parseVAST(vastXml, options)
   .then(res => {

--- a/docs/api/vast-parser.md
+++ b/docs/api/vast-parser.md
@@ -295,6 +295,8 @@ Returns a `Promise` which either resolves with the fully parsed `VASTResponse` o
   - `urlhandler: URLHandler` - Fulfills the same purpose as `urlHandler`, which is the preferred parameter to use
   - `allowMultipleAds: Boolean` - A boolean value that identifies whether multiple ads are allowed in the requested VAST response. This will override any value of allowMultipleAds attribute set in the VAST
   - `followAdditionalWrappers: Boolean` - A boolean value that identifies whether subsequent Wrappers after a requested VAST response is allowed. This will override any value of followAdditionalWrappers attribute set in the VAST
+  - `requestDuration: Number` - The fetching time of the XML. Provide it with byteLength to have a more accurate estimated bitrate.
+  - `byteLength: Number`- The size of the request. Provide it with requestDuration to have a more accurate estimated bitrate.
 
 #### Events emitted
 
@@ -324,6 +326,27 @@ const options = {
 vastParser.parseVAST(vastXml, options)
   .then(res => {
     // Do something with the parsed VAST response
+  })
+  .catch(err => {
+    // Deal with the error
+  });
+```
+
+### getEstimatedBitrate()
+
+Returns the average of the estimated bitrates in bits by secondes.
+
+#### Example
+
+```Javascript
+const options = {
+  requestDuration: 200,
+  byteLength 1000,
+}
+vastParser.parseVAST(vastXml, options)
+  .then(res => {
+    vastParser.getEstimatedBitrate()
+    // returns 40 000
   })
   .catch(err => {
     // Deal with the error
@@ -391,3 +414,12 @@ Merges the data between an unwrapped ad and his wrapper.
 
 - **`unwrappedAd: Ad`** - The 'unwrapped' Ad.
 - **`wrapper: Ad`** - The wrapper Ad.
+
+### updateEstimatedBitrate(byteLength, duration) {
+
+Calculate and add the estimated bitrate to the bitrates array.
+
+#### Parameters
+
+- **`byteLength: Number`** - The request response size, in bytes.
+- **`duration: Number`** - The request duration, in ms.

--- a/docs/api/vast-parser.md
+++ b/docs/api/vast-parser.md
@@ -414,12 +414,3 @@ Merges the data between an unwrapped ad and his wrapper.
 
 - **`unwrappedAd: Ad`** - The 'unwrapped' Ad.
 - **`wrapper: Ad`** - The wrapper Ad.
-
-### updateEstimatedBitrate(byteLength, duration) {
-
-Calculate and add the estimated bitrate to the bitrates array.
-
-#### Parameters
-
-- **`byteLength: Number`** - The request response size, in bytes.
-- **`duration: Number`** - The request duration, in ms.

--- a/spec/bitrate.spec.js
+++ b/spec/bitrate.spec.js
@@ -1,0 +1,30 @@
+import * as Bitrate from '../src/parser/bitrate';
+
+describe('updateEstimatedBitrate', () => {
+  beforeEach(() => {
+    Bitrate.estimatedBitrate = 0;
+  });
+
+  it('doesn\'t update estimated bitrate if one value is missing', () => {
+    Bitrate.updateEstimatedBitrate(1000, null);
+    expect(Bitrate.estimatedBitrate).toEqual(0);
+    Bitrate.updateEstimatedBitrate(null, 1234);
+    expect(Bitrate.estimatedBitrate).toEqual(0);
+  });
+
+  it('doesn\'t update estimated bitrate if one value is negative', () => {
+    Bitrate.updateEstimatedBitrate(1000, -12);
+    expect(Bitrate.estimatedBitrate).toEqual(0);
+    Bitrate.updateEstimatedBitrate(-243, 1234);
+    expect(Bitrate.estimatedBitrate).toEqual(0);
+  });
+
+  it('updates estimated bitrate if values are both positive and make the average from cumulated values', () => {
+    Bitrate.updateEstimatedBitrate(1000, 200);
+    expect(Bitrate.estimatedBitrate).toEqual(40000);
+    Bitrate.updateEstimatedBitrate(100, 200);
+    expect(Bitrate.estimatedBitrate).toEqual(22000);
+    Bitrate.updateEstimatedBitrate(43, 2000);
+    expect(Bitrate.estimatedBitrate).toEqual(14724);
+  });
+});

--- a/spec/bitrate.spec.js
+++ b/spec/bitrate.spec.js
@@ -5,14 +5,14 @@ describe('updateEstimatedBitrate', () => {
     Bitrate.estimatedBitrate = 0;
   });
 
-  it('doesn\'t update estimated bitrate if one value is missing', () => {
+  it('does not update estimated bitrate if one value is missing', () => {
     Bitrate.updateEstimatedBitrate(1000, null);
     expect(Bitrate.estimatedBitrate).toEqual(0);
     Bitrate.updateEstimatedBitrate(null, 1234);
     expect(Bitrate.estimatedBitrate).toEqual(0);
   });
 
-  it('doesn\'t update estimated bitrate if one value is negative', () => {
+  it('does not update estimated bitrate if one value is negative', () => {
     Bitrate.updateEstimatedBitrate(1000, -12);
     expect(Bitrate.estimatedBitrate).toEqual(0);
     Bitrate.updateEstimatedBitrate(-243, 1234);
@@ -21,10 +21,10 @@ describe('updateEstimatedBitrate', () => {
 
   it('updates estimated bitrate if values are both positive and make the average from cumulated values', () => {
     Bitrate.updateEstimatedBitrate(1000, 200);
-    expect(Bitrate.estimatedBitrate).toEqual(40000);
+    expect(Bitrate.estimatedBitrate).toEqual(40);
     Bitrate.updateEstimatedBitrate(100, 200);
-    expect(Bitrate.estimatedBitrate).toEqual(22000);
-    Bitrate.updateEstimatedBitrate(43, 2000);
-    expect(Bitrate.estimatedBitrate).toEqual(14724);
+    expect(Bitrate.estimatedBitrate).toEqual(22);
+    Bitrate.updateEstimatedBitrate(2050, 200);
+    expect(Bitrate.estimatedBitrate).toEqual(42);
   });
 });

--- a/spec/vast_parser.spec.js
+++ b/spec/vast_parser.spec.js
@@ -94,6 +94,14 @@ describe('VASTParser', () => {
         });
       });
 
+      it('updates the estimated bitrate', () => {
+        jest.spyOn(VastParser, 'updateEstimatedBitrate');
+
+        return VastParser.fetchVAST('www.foo.foo').finally(() => {
+          expect(VastParser.updateEstimatedBitrate).toHaveBeenCalledWith(1234, expect.any(Number));
+        });
+      })
+
       it('resolves with xml', () => {
         return expect(
           VastParser.fetchVAST('www.foo.foo', 2, 'www.original.foo')
@@ -165,12 +173,16 @@ describe('VASTParser', () => {
   describe('initParsingStatus', () => {
     it('assigns options to properties', () => {
       const urlHandler = jest.fn();
+      jest.spyOn(VastParser, 'updateEstimatedBitrate');
+
       VastParser.initParsingStatus({
         wrapperLimit: 5,
         timeout: 1000,
         withCredentials: true,
         urlHandler,
         allowMultipleAds: true,
+        byteLength: 1000,
+        requestDuration: 200,
       });
 
       expect(VastParser.rootURL).toBe('');
@@ -186,6 +198,7 @@ describe('VASTParser', () => {
       expect(VastParser.urlHandler).toEqual(urlHandler);
       expect(VastParser.vastVersion).toBeNull();
       expect(VastParser.parsingOptions).toEqual({ allowMultipleAds: true });
+      expect(VastParser.updateEstimatedBitrate).toBeCalledWith(1000, 200);
     });
 
     it('uses default values if no options are passed', () => {
@@ -871,6 +884,50 @@ describe('VASTParser', () => {
           expect.objectContaining(expectedValue)
         );
       });
+    });
+  });
+
+  describe('updateEstimatedBitrate', () => {
+    beforeEach(() => {
+      VastParser.estimatedBitrates = [];
+    });
+
+    it('doesn\'t update estimated bitrate if one value is missing', () => {
+      VastParser.updateEstimatedBitrate(1000, null);
+      expect(VastParser.estimatedBitrates).toEqual([]);
+      VastParser.updateEstimatedBitrate(null, 1234);
+      expect(VastParser.estimatedBitrates).toEqual([]);
+    });
+
+    it('doesn\'t update estimated bitrate if one value is negative', () => {
+      VastParser.updateEstimatedBitrate(1000, -12);
+      expect(VastParser.estimatedBitrates).toEqual([]);
+      VastParser.updateEstimatedBitrate(-243, 1234);
+      expect(VastParser.estimatedBitrates).toEqual([]);
+    });
+
+    it('updates estimated bitrate if values are both positive and cumulates', () => {
+      VastParser.updateEstimatedBitrate(1000, 200);
+      expect(VastParser.estimatedBitrates).toEqual([40000]);
+      VastParser.updateEstimatedBitrate(100, 200);
+      expect(VastParser.estimatedBitrates).toEqual([40000, 4000]);
+    });
+  });
+
+  describe('getEstimatedBitrate', () => {
+    beforeEach(() => {
+      VastParser.estimatedBitrates = [];
+    });
+
+    it('returns 0 when the array is empty', () => {
+      expect(VastParser.getEstimatedBitrate()).toEqual(0);
+    });
+
+    it('returns the average otherwise', () => {
+      VastParser.estimatedBitrates = [42];
+      expect(VastParser.getEstimatedBitrate()).toEqual(42);
+      VastParser.estimatedBitrates = [42, 4000];
+      expect(VastParser.getEstimatedBitrate()).toEqual(2021);
     });
   });
 });

--- a/spec/vast_parser.spec.js
+++ b/spec/vast_parser.spec.js
@@ -3,6 +3,7 @@ import { nodeURLHandler } from '../src/urlhandlers/node_url_handler';
 import { urlFor, fetchXml } from './utils/utils';
 import { util } from '../src/util/util';
 import { parserUtils } from '../src/parser/parser_utils';
+import * as Bitrate from '../src/parser/bitrate';
 
 const xml = new DOMParser().parseFromString('<VAST></VAST>', 'text/xml');
 const urlHandlerSuccess = {
@@ -95,10 +96,10 @@ describe('VASTParser', () => {
       });
 
       it('updates the estimated bitrate', () => {
-        jest.spyOn(VastParser, 'updateEstimatedBitrate');
+        jest.spyOn(Bitrate, 'updateEstimatedBitrate');
 
         return VastParser.fetchVAST('www.foo.foo').finally(() => {
-          expect(VastParser.updateEstimatedBitrate).toHaveBeenCalledWith(1234, expect.any(Number));
+          expect(Bitrate.updateEstimatedBitrate).toHaveBeenCalledWith(1234, expect.any(Number));
         });
       })
 
@@ -173,7 +174,7 @@ describe('VASTParser', () => {
   describe('initParsingStatus', () => {
     it('assigns options to properties', () => {
       const urlHandler = jest.fn();
-      jest.spyOn(VastParser, 'updateEstimatedBitrate');
+      jest.spyOn(Bitrate, 'updateEstimatedBitrate');
 
       VastParser.initParsingStatus({
         wrapperLimit: 5,
@@ -198,7 +199,7 @@ describe('VASTParser', () => {
       expect(VastParser.urlHandler).toEqual(urlHandler);
       expect(VastParser.vastVersion).toBeNull();
       expect(VastParser.parsingOptions).toEqual({ allowMultipleAds: true });
-      expect(VastParser.updateEstimatedBitrate).toBeCalledWith(1000, 200);
+      expect(Bitrate.updateEstimatedBitrate).toBeCalledWith(1000, 200);
     });
 
     it('uses default values if no options are passed', () => {
@@ -887,47 +888,10 @@ describe('VASTParser', () => {
     });
   });
 
-  describe('updateEstimatedBitrate', () => {
-    beforeEach(() => {
-      VastParser.estimatedBitrates = [];
-    });
-
-    it('doesn\'t update estimated bitrate if one value is missing', () => {
-      VastParser.updateEstimatedBitrate(1000, null);
-      expect(VastParser.estimatedBitrates).toEqual([]);
-      VastParser.updateEstimatedBitrate(null, 1234);
-      expect(VastParser.estimatedBitrates).toEqual([]);
-    });
-
-    it('doesn\'t update estimated bitrate if one value is negative', () => {
-      VastParser.updateEstimatedBitrate(1000, -12);
-      expect(VastParser.estimatedBitrates).toEqual([]);
-      VastParser.updateEstimatedBitrate(-243, 1234);
-      expect(VastParser.estimatedBitrates).toEqual([]);
-    });
-
-    it('updates estimated bitrate if values are both positive and cumulates', () => {
-      VastParser.updateEstimatedBitrate(1000, 200);
-      expect(VastParser.estimatedBitrates).toEqual([40000]);
-      VastParser.updateEstimatedBitrate(100, 200);
-      expect(VastParser.estimatedBitrates).toEqual([40000, 4000]);
-    });
-  });
-
   describe('getEstimatedBitrate', () => {
-    beforeEach(() => {
-      VastParser.estimatedBitrates = [];
-    });
-
-    it('returns 0 when the array is empty', () => {
-      expect(VastParser.getEstimatedBitrate()).toEqual(0);
-    });
-
-    it('returns the average otherwise', () => {
-      VastParser.estimatedBitrates = [42];
+    it('should return value from imported estimatedBitrate', () => {
+      Bitrate.estimatedBitrate = 42;
       expect(VastParser.getEstimatedBitrate()).toEqual(42);
-      VastParser.estimatedBitrates = [42, 4000];
-      expect(VastParser.getEstimatedBitrate()).toEqual(2021);
-    });
-  });
+    })
+  })
 });

--- a/src/parser/bitrate.js
+++ b/src/parser/bitrate.js
@@ -15,7 +15,7 @@ export const updateEstimatedBitrate = (byteLength, duration) => {
     return;
   }
 
-  // We want the bitrate in bit by seconds, byteLength are in bytes and duration in ms, we need to convert them
-  const bitrate = (byteLength * 8) / duration * 1000;
+  // We want the bitrate in kb/s, byteLength are in bytes and duration in ms, just need to convert the byteLength because kb/s = b/ms
+  const bitrate = (byteLength * 8) / duration;
   estimatedBitrate = (estimatedBitrate * estimatedBitrateCount + bitrate) / ++estimatedBitrateCount
 }

--- a/src/parser/bitrate.js
+++ b/src/parser/bitrate.js
@@ -1,0 +1,21 @@
+/*
+  We decided to put the estimated bitrate separated from classes to persist it between different instances of vast client/parser
+*/
+
+let estimatedBitrateCount = 0;
+export let estimatedBitrate = 0;
+
+/**
+ * Calculate average estimated bitrate from the previous values and new entries
+ * @param {Number} byteLength - The length of the response in bytes.
+ * @param {Number} duration - The duration of the request in ms.
+ */
+export const updateEstimatedBitrate = (byteLength, duration) => {
+  if (!byteLength || !duration || byteLength <= 0 || duration <= 0) {
+    return;
+  }
+
+  // We want the bitrate in bit by seconds, byteLength are in bytes and duration in ms, we need to convert them
+  const bitrate = (byteLength * 8) / duration * 1000;
+  estimatedBitrate = (estimatedBitrate * estimatedBitrateCount + bitrate) / ++estimatedBitrateCount
+}

--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -98,7 +98,7 @@ export class VASTParser extends EventEmitter {
 
   /**
    * Returns the estimated bitrate calculated from all previous requests
-   * @returns The average of all estimated bitrates.
+   * @returns The average of all estimated bitrates in kb/s.
    */
   getEstimatedBitrate() {
     return estimatedBitrate


### PR DESCRIPTION
### Description

This PR provides a bitrate estimation from the VAST resolution requests.

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
