### PR TITLE
[parser] Merge correctly adVerification from extension and from its own node

### DIFF
--- a/spec/ad_parser.spec.js
+++ b/spec/ad_parser.spec.js
@@ -3,7 +3,7 @@ import { getNodesFromXml } from './utils/utils';
 import { parserUtils } from '../src/parser/parser_utils';
 import { linearAd } from './samples/linear_ads';
 import { adVerificationExtensions } from './samples/ad_verification_extentions';
-import { adVerificationFromExtensionsNodeAndFromNode } from './samples/ad_verification_extension_and_node';
+import { adVerificationsInDedicatedNodeAndInExtensionsNode } from './samples/ad_verification_extension_and_node';
 import {
   viewableImpression,
   viewableImpressionPartial,
@@ -198,34 +198,34 @@ describe('AdParser', function () {
 
     beforeAll(() => {
       adVerificationsFromAd = getNodesFromXml(
-        adVerificationFromExtensionsNodeAndFromNode
+        adVerificationsInDedicatedNodeAndInExtensionsNode
       );
       ad = parseAd(adVerificationsFromAd, null).ad;
     });
 
-    it('should have 4 adVerifications', () => {
+    it('should have 4 adVerification', () => {
       expect(ad.adVerifications).toHaveLength(4);
     });
 
     it('validate first adVerification', () => {
       expect(ad.adVerifications[0].resource).toEqual(
-        'https://verificationcompany.com/iaminadverifications1.js'
+        'https://verificationcompany.com/dedicatedNodeAdVerification1.js'
       );
     });
 
     it('validate second adVerification', () => {
       expect(ad.adVerifications[1].resource).toEqual(
-        'https://verificationcompany.com/iaminadverifications2.js'
+        'https://verificationcompany.com/dedicatedNodeAdVerification2.js'
       );
     });
     it('validate the third adVerification', () => {
       expect(ad.adVerifications[2].resource).toEqual(
-        'https://verificationcompany.com/iamintheextension1.js'
+        'https://verificationcompany.com/extentionAdVerification1.js'
       );
     });
     it('validate the fourth adVerification', () => {
       expect(ad.adVerifications[3].resource).toEqual(
-        'https://verificationcompany.com/iamintheextension2.js'
+        'https://verificationcompany.com/extentionAdVerification2.js'
       );
     });
   });
@@ -238,7 +238,7 @@ describe('AdParser', function () {
       ad = parseAd(adVerificationExtensionsNode, null).ad;
     });
 
-    it('should have 2 adVerifications', () => {
+    it('should have 2 adVerification', () => {
       expect(ad.adVerifications).toHaveLength(2);
     });
 

--- a/spec/ad_parser.spec.js
+++ b/spec/ad_parser.spec.js
@@ -3,13 +3,14 @@ import { getNodesFromXml } from './utils/utils';
 import { parserUtils } from '../src/parser/parser_utils';
 import { linearAd } from './samples/linear_ads';
 import { adVerificationExtensions } from './samples/ad_verification_extentions';
+import { adVerificationFromExtensionsNodeAndFromNode } from './samples/ad_verification_extension_and_node';
 import {
   viewableImpression,
-  viewableImpressionPartial
+  viewableImpressionPartial,
 } from './samples/viewable_impression';
 
-describe('AdParser', function() {
-  describe('parseAd', function() {
+describe('AdParser', function () {
+  describe('parseAd', function () {
     let inlineAdNode, wrapperAdNode, invalidAdNode, adElement, ad;
     const emit = () => {};
 
@@ -37,9 +38,9 @@ describe('AdParser', function() {
         ad: expect.objectContaining({
           id: 'id-123',
           sequence: 'seq-123',
-          adType: null
+          adType: null,
         }),
-        type: 'INLINE'
+        type: 'INLINE',
       });
     });
 
@@ -48,11 +49,11 @@ describe('AdParser', function() {
       expect(parsedWrapper.ad).toMatchObject({
         allowMultipleAds: true,
         fallbackOnNoAd: true,
-        followAdditionalWrappers: false
+        followAdditionalWrappers: false,
       });
       expect(parsedWrapper).toEqual({
         ad: expect.any(Object),
-        type: 'WRAPPER'
+        type: 'WRAPPER',
       });
     });
 
@@ -99,24 +100,24 @@ describe('AdParser', function() {
       expect(ad.viewableImpression.viewable).toHaveLength(2);
       expect(ad.viewableImpression.viewable).toEqual([
         'http://www.example.com/viewable_impression_1',
-        'http://www.sample.com/viewable_impression_2'
+        'http://www.sample.com/viewable_impression_2',
       ]);
       expect(ad.viewableImpression.notviewable).toHaveLength(3);
       expect(ad.viewableImpression.notviewable).toEqual([
         'http://www.example.com/not_viewable_1',
         'http://www.sample.com/not_viewable_2',
-        'http://www.sample.com/not_viewable_3'
+        'http://www.sample.com/not_viewable_3',
       ]);
       expect(ad.viewableImpression.viewundetermined).toHaveLength(1);
       expect(ad.viewableImpression.viewundetermined).toEqual([
-        'http://www.example.com/view_undetermined_1'
+        'http://www.example.com/view_undetermined_1',
       ]);
     });
 
     it('returns 1 errorURLTemplate', () => {
       expect(ad.errorURLTemplates).toHaveLength(1);
       expect(ad.errorURLTemplates).toEqual([
-        'http://example.com/error_[ERRORCODE]'
+        'http://example.com/error_[ERRORCODE]',
       ]);
     });
 
@@ -125,16 +126,16 @@ describe('AdParser', function() {
       expect(ad.impressionURLTemplates).toEqual([
         {
           id: 'sample-impression1',
-          url: 'http://example.com/impression1_asset:[ASSETURI]_[CACHEBUSTING]'
+          url: 'http://example.com/impression1_asset:[ASSETURI]_[CACHEBUSTING]',
         },
         {
           id: 'sample-impression2',
-          url: 'http://example.com/impression2_[random]'
+          url: 'http://example.com/impression2_[random]',
         },
         {
           id: 'sample-impression3',
-          url: 'http://example.com/impression3_[RANDOM]'
-        }
+          url: 'http://example.com/impression3_[RANDOM]',
+        },
       ]);
     });
 
@@ -187,12 +188,49 @@ describe('AdParser', function() {
         ad.adVerifications[2].trackingEvents.verificationNotExecuted
       ).toEqual([
         'http://example.com/verification-not-executed-EXE',
-        'http://sample.com/verification-not-executed-EXE'
+        'http://sample.com/verification-not-executed-EXE',
       ]);
     });
   });
 
-  describe('adVerifications from extensions', function() {
+  describe('parse adVerifications from extensions and parent node', function () {
+    let adVerificationsFromAd, ad;
+
+    beforeAll(() => {
+      adVerificationsFromAd = getNodesFromXml(
+        adVerificationFromExtensionsNodeAndFromNode
+      );
+      ad = parseAd(adVerificationsFromAd, null).ad;
+    });
+
+    it('should have 4 adVerifications', () => {
+      expect(ad.adVerifications).toHaveLength(4);
+    });
+
+    it('validate first adVerification', () => {
+      expect(ad.adVerifications[0].resource).toEqual(
+        'https://verificationcompany.com/iaminadverifications1.js'
+      );
+    });
+
+    it('validate second adVerification', () => {
+      expect(ad.adVerifications[1].resource).toEqual(
+        'https://verificationcompany.com/iaminadverifications2.js'
+      );
+    });
+    it('validate the third adVerification', () => {
+      expect(ad.adVerifications[2].resource).toEqual(
+        'https://verificationcompany.com/iamintheextension1.js'
+      );
+    });
+    it('validate the fourth adVerification', () => {
+      expect(ad.adVerifications[3].resource).toEqual(
+        'https://verificationcompany.com/iamintheextension2.js'
+      );
+    });
+  });
+
+  describe('adVerifications from extensions', function () {
     let adVerificationExtensionsNode, ad;
 
     beforeAll(() => {
@@ -225,7 +263,7 @@ describe('AdParser', function() {
     });
   });
 
-  describe('parseViewableImpression', function() {
+  describe('parseViewableImpression', function () {
     const viewableImpressionNode = parserUtils.childByName(
       getNodesFromXml(viewableImpression),
       'ViewableImpression'
@@ -253,7 +291,7 @@ describe('AdParser', function() {
       expect(parsedViewableImpression.viewable.length).toEqual(2);
       expect(parsedViewableImpression.viewable).toEqual([
         'http://www.example.com/viewable_impression_1',
-        'http://www.sample.com/viewable_impression_2'
+        'http://www.sample.com/viewable_impression_2',
       ]);
     });
 
@@ -262,14 +300,14 @@ describe('AdParser', function() {
       expect(parsedViewableImpression.notviewable).toEqual([
         'http://www.example.com/not_viewable_1',
         'http://www.sample.com/not_viewable_2',
-        'http://www.sample.com/not_viewable_3'
+        'http://www.sample.com/not_viewable_3',
       ]);
     });
 
     it('validate viewableImpression viewundetermined array', () => {
       expect(parsedViewableImpression.viewundetermined.length).toEqual(1);
       expect(parsedViewableImpression.viewundetermined).toEqual([
-        'http://www.example.com/view_undetermined_1'
+        'http://www.example.com/view_undetermined_1',
       ]);
     });
 
@@ -280,7 +318,7 @@ describe('AdParser', function() {
     it('validate viewableImpressionPartial viewable array', () => {
       expect(parsedViewableImpressionPartial.viewable.length).toEqual(1);
       expect(parsedViewableImpressionPartial.viewable).toEqual([
-        'http://www.example.com/viewable_impression_1'
+        'http://www.example.com/viewable_impression_1',
       ]);
     });
 

--- a/spec/samples/ad_verification_extension_and_node.js
+++ b/spec/samples/ad_verification_extension_and_node.js
@@ -1,0 +1,79 @@
+export const adVerificationFromExtensionsNodeAndFromNode = `
+<Ad id="20001" sequence="1" conditionalAd="false">
+<InLine>
+<Extensions>
+<Extension type="iab-Count">
+<total_available>
+<![CDATA[ 2 ]]>
+</total_available>
+</Extension>
+<Extension type="dailymotion">
+<AdVerifications>
+<Verification>
+<JavaScriptResource>
+<![CDATA[ https://verificationcompany.com/iamintheextension1.js ]]>
+</JavaScriptResource>
+</Verification>
+<Verification>
+<JavaScriptResource>
+<![CDATA[ https://verificationcompany.com/iamintheextension2.js ]]>
+</JavaScriptResource>
+</Verification>
+</AdVerifications>
+</Extension>
+</Extensions>
+<AdSystem version="4.0">iabtechlab</AdSystem>
+<Error>http://example.com/error</Error>
+<Impression id="Impression-ID">http://example.com/track/impression</Impression>
+<Pricing model="cpm" currency="USD">
+<![CDATA[ 25.00 ]]>
+</Pricing>
+<AdTitle>Inline Simple Ad</AdTitle>
+<AdVerifications>
+<Verification>
+<JavaScriptResource>
+<![CDATA[ https://verificationcompany.com/iaminadverifications1.js ]]>
+</JavaScriptResource>
+</Verification>
+<Verification>
+<JavaScriptResource>
+<![CDATA[ https://verificationcompany.com/iaminadverifications2.js ]]>
+</JavaScriptResource>
+</Verification>
+</AdVerifications>
+<Advertiser>IAB Sample Company</Advertiser>
+<Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
+<Creatives>
+<Creative id="5480" sequence="1" adId="2447226">
+<UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+<Linear>
+<TrackingEvents>
+<Tracking event="start">http://example.com/tracking/start</Tracking>
+<Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
+<Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
+<Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
+<Tracking event="complete">http://example.com/tracking/complete</Tracking>
+<Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
+</TrackingEvents>
+<Duration>00:00:16</Duration>
+<MediaFiles>
+<MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="H.264">
+<![CDATA[ https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro.mp4 ]]>
+</MediaFile>
+<MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="H.264">
+<![CDATA[ https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro-mid-resolution.mp4 ]]>
+</MediaFile>
+<MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="H.264">
+<![CDATA[ https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro-low-resolution.mp4 ]]>
+</MediaFile>
+</MediaFiles>
+<VideoClicks>
+<ClickThrough id="blog">
+<![CDATA[ https://iabtechlab.com ]]>
+</ClickThrough>
+</VideoClicks>
+</Linear>
+</Creative>
+</Creatives>
+</InLine>
+</Ad>`;

--- a/spec/samples/ad_verification_extension_and_node.js
+++ b/spec/samples/ad_verification_extension_and_node.js
@@ -1,79 +1,43 @@
-export const adVerificationFromExtensionsNodeAndFromNode = `
+export const adVerificationsInDedicatedNodeAndInExtensionsNode = `
 <Ad id="20001" sequence="1" conditionalAd="false">
-<InLine>
-<Extensions>
-<Extension type="iab-Count">
-<total_available>
-<![CDATA[ 2 ]]>
-</total_available>
-</Extension>
-<Extension type="dailymotion">
-<AdVerifications>
-<Verification>
-<JavaScriptResource>
-<![CDATA[ https://verificationcompany.com/iamintheextension1.js ]]>
-</JavaScriptResource>
-</Verification>
-<Verification>
-<JavaScriptResource>
-<![CDATA[ https://verificationcompany.com/iamintheextension2.js ]]>
-</JavaScriptResource>
-</Verification>
-</AdVerifications>
-</Extension>
-</Extensions>
-<AdSystem version="4.0">iabtechlab</AdSystem>
-<Error>http://example.com/error</Error>
-<Impression id="Impression-ID">http://example.com/track/impression</Impression>
-<Pricing model="cpm" currency="USD">
-<![CDATA[ 25.00 ]]>
-</Pricing>
-<AdTitle>Inline Simple Ad</AdTitle>
-<AdVerifications>
-<Verification>
-<JavaScriptResource>
-<![CDATA[ https://verificationcompany.com/iaminadverifications1.js ]]>
-</JavaScriptResource>
-</Verification>
-<Verification>
-<JavaScriptResource>
-<![CDATA[ https://verificationcompany.com/iaminadverifications2.js ]]>
-</JavaScriptResource>
-</Verification>
-</AdVerifications>
-<Advertiser>IAB Sample Company</Advertiser>
-<Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
-<Creatives>
-<Creative id="5480" sequence="1" adId="2447226">
-<UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
-<Linear>
-<TrackingEvents>
-<Tracking event="start">http://example.com/tracking/start</Tracking>
-<Tracking event="firstQuartile">http://example.com/tracking/firstQuartile</Tracking>
-<Tracking event="midpoint">http://example.com/tracking/midpoint</Tracking>
-<Tracking event="thirdQuartile">http://example.com/tracking/thirdQuartile</Tracking>
-<Tracking event="complete">http://example.com/tracking/complete</Tracking>
-<Tracking event="progress" offset="00:00:10">http://example.com/tracking/progress-10</Tracking>
-</TrackingEvents>
-<Duration>00:00:16</Duration>
-<MediaFiles>
-<MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="H.264">
-<![CDATA[ https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro.mp4 ]]>
-</MediaFile>
-<MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="H.264">
-<![CDATA[ https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro-mid-resolution.mp4 ]]>
-</MediaFile>
-<MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="H.264">
-<![CDATA[ https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro-low-resolution.mp4 ]]>
-</MediaFile>
-</MediaFiles>
-<VideoClicks>
-<ClickThrough id="blog">
-<![CDATA[ https://iabtechlab.com ]]>
-</ClickThrough>
-</VideoClicks>
-</Linear>
-</Creative>
-</Creatives>
-</InLine>
-</Ad>`;
+   <InLine>
+      <Extensions>
+         <Extension type="iab">
+            <AdVerifications>
+               <Verification>
+                  <JavaScriptResource><![CDATA[https://verificationcompany.com/extentionAdVerification1.js]]></JavaScriptResource>
+               </Verification>
+               <Verification>
+                  <JavaScriptResource><![CDATA[https://verificationcompany.com/extentionAdVerification2.js]]></JavaScriptResource>
+               </Verification>
+            </AdVerifications>
+         </Extension>
+      </Extensions>
+      <AdSystem version="4.0">iabtechlab</AdSystem>
+      <AdTitle>Inline Simple Ad</AdTitle>
+      <AdVerifications>
+         <Verification>
+            <JavaScriptResource><![CDATA[https://verificationcompany.com/dedicatedNodeAdVerification1.js]]></JavaScriptResource>
+         </Verification>
+         <Verification>
+            <JavaScriptResource><![CDATA[https://verificationcompany.com/dedicatedNodeAdVerification2.js]]></JavaScriptResource>
+         </Verification>
+      </AdVerifications>
+      <Advertiser>IAB Sample Company</Advertiser>
+      <Category authority="http://www.iabtechlab.com/categoryauthority">AD CONTENT description category</Category>
+      <Creatives>
+         <Creative id="5480" sequence="1" adId="2447226">
+            <UniversalAdId idRegistry="Ad-ID" idValue="8465">8465</UniversalAdId>
+            <Linear>
+               <Duration>00:00:16</Duration>
+               <MediaFiles>
+                  <MediaFile id="5241" delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720" minBitrate="1500" maxBitrate="2500" scalable="1" maintainAspectRatio="1" codec="H.264"><![CDATA[https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro.mp4]]></MediaFile>
+                  <MediaFile id="5244" delivery="progressive" type="video/mp4" bitrate="1000" width="854" height="480" minBitrate="700" maxBitrate="1500" scalable="1" maintainAspectRatio="1" codec="H.264"><![CDATA[https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro-mid-resolution.mp4]]></MediaFile>
+                  <MediaFile id="5246" delivery="progressive" type="video/mp4" bitrate="600" width="640" height="360" minBitrate="500" maxBitrate="700" scalable="1" maintainAspectRatio="1" codec="H.264"><![CDATA[https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro-low-resolution.mp4]]></MediaFile>
+               </MediaFiles>
+            </Linear>
+         </Creative>
+      </Creatives>
+   </InLine>
+</Ad>
+`;

--- a/src/parser/ad_parser.js
+++ b/src/parser/ad_parser.js
@@ -191,7 +191,7 @@ function parseAdElement(adTypeElement, emit) {
     }
   }
 
-  if (adVerificationFromExtensions.length) {
+  if (adVerificationFromExtensions.length && ad.system.version < 4.1) {
     ad.adVerifications = ad.adVerifications.concat(
       adVerificationFromExtensions
     );

--- a/src/parser/ad_parser.js
+++ b/src/parser/ad_parser.js
@@ -46,7 +46,7 @@ export function parseAd(
     } else if (adTypeElement.nodeName === 'InLine') {
       return {
         ad: parseInLine(adTypeElement, emit, { allowMultipleAds }),
-        type: 'INLINE'
+        type: 'INLINE',
       };
     }
   }
@@ -79,6 +79,7 @@ function parseInLine(adElement, emit, { allowMultipleAds } = {}) {
  * @return {Object} ad - The ad object.
  */
 function parseAdElement(adTypeElement, emit) {
+  let adVerificationFromExtensions = [];
   if (emit) {
     parserVerification.verifyRequiredValues(adTypeElement, emit);
   }
@@ -96,7 +97,7 @@ function parseAdElement(adTypeElement, emit) {
       case 'Impression':
         ad.impressionURLTemplates.push({
           id: node.getAttribute('id') || null,
-          url: parserUtils.parseNodeText(node)
+          url: parserUtils.parseNodeText(node),
         });
         break;
 
@@ -116,7 +117,9 @@ function parseAdElement(adTypeElement, emit) {
           from extensions the same way than for an AdVerifications node.
         */
         if (!ad.adVerifications.length) {
-          ad.adVerifications = _parseAdVerificationsFromExensions(extNodes);
+          adVerificationFromExtensions = _parseAdVerificationsFromExensions(
+            extNodes
+          );
         }
         break;
       }
@@ -129,7 +132,7 @@ function parseAdElement(adTypeElement, emit) {
       case 'AdSystem':
         ad.system = {
           value: parserUtils.parseNodeText(node),
-          version: node.getAttribute('version') || null
+          version: node.getAttribute('version') || null,
         };
         break;
 
@@ -144,7 +147,7 @@ function parseAdElement(adTypeElement, emit) {
       case 'Category':
         ad.categories.push({
           authority: node.getAttribute('authority') || null,
-          value: parserUtils.parseNodeText(node)
+          value: parserUtils.parseNodeText(node),
         });
         break;
 
@@ -163,7 +166,7 @@ function parseAdElement(adTypeElement, emit) {
       case 'Advertiser':
         ad.advertiser = {
           id: node.getAttribute('id') || null,
-          value: parserUtils.parseNodeText(node)
+          value: parserUtils.parseNodeText(node),
         };
         break;
 
@@ -171,7 +174,7 @@ function parseAdElement(adTypeElement, emit) {
         ad.pricing = {
           value: parserUtils.parseNodeText(node),
           model: node.getAttribute('model') || null,
-          currency: node.getAttribute('currency') || null
+          currency: node.getAttribute('currency') || null,
         };
         break;
 
@@ -182,12 +185,17 @@ function parseAdElement(adTypeElement, emit) {
       case 'BlockedAdCategories':
         ad.blockedAdCategories.push({
           authority: node.getAttribute('authority') || null,
-          value: parserUtils.parseNodeText(node)
+          value: parserUtils.parseNodeText(node),
         });
         break;
     }
   }
 
+  if (adVerificationFromExtensions.length) {
+    ad.adVerifications = ad.adVerifications.concat(
+      adVerificationFromExtensions
+    );
+  }
   return ad;
 }
 
@@ -235,7 +243,7 @@ function parseWrapper(wrapperElement, emit) {
     }
   }
 
-  ad.creatives.forEach(wrapperCreativeElement => {
+  ad.creatives.forEach((wrapperCreativeElement) => {
     if (['linear', 'nonlinear'].indexOf(wrapperCreativeElement.type) !== -1) {
       // TrackingEvents Linear / NonLinear
       if (wrapperCreativeElement.trackingEvents) {
@@ -254,7 +262,7 @@ function parseWrapper(wrapperElement, emit) {
           ) {
             ad.trackingEvents[wrapperCreativeElement.type][eventName] = [];
           }
-          urls.forEach(url => {
+          urls.forEach((url) => {
             ad.trackingEvents[wrapperCreativeElement.type][eventName].push(url);
           });
         }
@@ -264,9 +272,11 @@ function parseWrapper(wrapperElement, emit) {
         if (!Array.isArray(ad.videoClickTrackingURLTemplates)) {
           ad.videoClickTrackingURLTemplates = [];
         } // tmp property to save wrapper tracking URLs until they are merged
-        wrapperCreativeElement.videoClickTrackingURLTemplates.forEach(item => {
-          ad.videoClickTrackingURLTemplates.push(item);
-        });
+        wrapperCreativeElement.videoClickTrackingURLTemplates.forEach(
+          (item) => {
+            ad.videoClickTrackingURLTemplates.push(item);
+          }
+        );
       }
       // ClickThrough
       if (wrapperCreativeElement.videoClickThroughURLTemplate) {
@@ -278,7 +288,7 @@ function parseWrapper(wrapperElement, emit) {
         if (!Array.isArray(ad.videoCustomClickURLTemplates)) {
           ad.videoCustomClickURLTemplates = [];
         } // tmp property to save wrapper tracking URLs until they are merged
-        wrapperCreativeElement.videoCustomClickURLTemplates.forEach(item => {
+        wrapperCreativeElement.videoCustomClickURLTemplates.forEach((item) => {
           ad.videoCustomClickURLTemplates.push(item);
         });
       }
@@ -298,7 +308,7 @@ function parseWrapper(wrapperElement, emit) {
 export function _parseAdVerifications(verifications) {
   const ver = [];
 
-  verifications.forEach(verificationNode => {
+  verifications.forEach((verificationNode) => {
     const verification = createAdVerification();
     const childNodes = verificationNode.childNodes;
 
@@ -325,7 +335,7 @@ export function _parseAdVerifications(verifications) {
     if (trackingEventsElement) {
       parserUtils
         .childrenByName(trackingEventsElement, 'Tracking')
-        .forEach(trackingElement => {
+        .forEach((trackingElement) => {
           const eventName = trackingElement.getAttribute('event');
           const trackingURLTemplate = parserUtils.parseNodeText(
             trackingElement
@@ -355,7 +365,7 @@ export function _parseAdVerificationsFromExensions(extensions) {
     adVerifications = [];
 
   // Find the first (and only) AdVerifications node from extensions
-  extensions.some(extension => {
+  extensions.some((extension) => {
     return (adVerificationsNode = parserUtils.childByName(
       extension,
       'AdVerifications'
@@ -368,7 +378,6 @@ export function _parseAdVerificationsFromExensions(extensions) {
       parserUtils.childrenByName(adVerificationsNode, 'Verification')
     );
   }
-
   return adVerifications;
 }
 

--- a/src/parser/ad_parser.js
+++ b/src/parser/ad_parser.js
@@ -191,7 +191,7 @@ function parseAdElement(adTypeElement, emit) {
     }
   }
 
-  if (adVerificationsFromExtensions.length && ad.system.version < 4.1) {
+  if (adVerificationsFromExtensions.length) {
     ad.adVerifications = ad.adVerifications.concat(
       adVerificationsFromExtensions
     );

--- a/src/parser/ad_parser.js
+++ b/src/parser/ad_parser.js
@@ -79,7 +79,7 @@ function parseInLine(adElement, emit, { allowMultipleAds } = {}) {
  * @return {Object} ad - The ad object.
  */
 function parseAdElement(adTypeElement, emit) {
-  let adVerificationFromExtensions = [];
+  let adVerificationsFromExtensions = [];
   if (emit) {
     parserVerification.verifyRequiredValues(adTypeElement, emit);
   }
@@ -117,7 +117,7 @@ function parseAdElement(adTypeElement, emit) {
           from extensions the same way than for an AdVerifications node.
         */
         if (!ad.adVerifications.length) {
-          adVerificationFromExtensions = _parseAdVerificationsFromExensions(
+          adVerificationsFromExtensions = _parseAdVerificationsFromExtensions(
             extNodes
           );
         }
@@ -191,9 +191,9 @@ function parseAdElement(adTypeElement, emit) {
     }
   }
 
-  if (adVerificationFromExtensions.length && ad.system.version < 4.1) {
+  if (adVerificationsFromExtensions.length && ad.system.version < 4.1) {
     ad.adVerifications = ad.adVerifications.concat(
-      adVerificationFromExtensions
+      adVerificationsFromExtensions
     );
   }
   return ad;
@@ -360,7 +360,7 @@ export function _parseAdVerifications(verifications) {
  * @param  {Array<Node>} extensions - The array of extensions to parse.
  * @return {Array<Object>}
  */
-export function _parseAdVerificationsFromExensions(extensions) {
+export function _parseAdVerificationsFromExtensions(extensions) {
   let adVerificationsNode = null,
     adVerifications = [];
 


### PR DESCRIPTION
### Description

Since VAST 4.1, the adVerification tag isn't in the extensions anymore but has its own node, but it can happen that a VAST contains adVerifications node in the extensions and also in the dedicated AdVerifications node, if that's the case, the vast-parser parse the one from the extension but don't merge it inside the property adVerification of the final parsed ad object, as it should. 

### Type
- [ ] Breaking change
- [ ] Enhancement
- [X] Fix
- [ ] Documentation
- [ ] Tooling
