### PR TITLE
[fix] Safari cors error 

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -98,9 +98,9 @@ function replaceMacrosValues(url, macros) {
   let replacedMacrosUrl = url;
   for (const key in macros) {
     const value = macros[key];
-    // this will match [${key}] and %%${key}%% and replace it
+    // this will match [${key}] and %%${key}%% and %5B{key}%5D and replace it
     replacedMacrosUrl = replacedMacrosUrl.replace(
-      new RegExp(`(?:\\[|%%)(${key})(?:\\]|%%)`, 'g'),
+      new RegExp(`(?:\\[|%{2}|%5B)(${key})(?:\\]|%{2}|%5D)`, 'g'),
       value
     );
   }


### PR DESCRIPTION
[client][parser] 
When you use in iframe on Safari vastClient can't get VAST. Request is block by CORS.

### Description

- Migrate from xmlhttprequest to fetch. Fetch select between 2 modes: 'cors' : 'no-cors' depends on options.withCredentials
- To macros added support pattern %5B{key}%5D

### Issue

Issue Link [Optional]

### Type
- [ ] Breaking change
- [ ✔️ ] Enhancement
- [ ✔️ ] Fix
- [ ] Documentation
- [ ] Tooling
