### PR TITLE
Ad data on resolving events

### DIFF
--- a/docs/api/vast-parser.md
+++ b/docs/api/vast-parser.md
@@ -87,7 +87,7 @@ Event is triggered when `fetchVAST` function is called, before the fetching star
 - `wrapperDepth: Number`
 - `maxWrapperDepth: Number`
 - `timeout: Number`
-- `ad: Ad`
+- `wrapperAd: Ad`
 
 ```Javascript
 vastParser.on('VAST-resolving', ({ url, wrapperDepth, previousUrl }) => {
@@ -216,7 +216,7 @@ Tracks the error provided in the errorCode parameter and emits a `VAST-error` ev
 - **`errorCode: Object`** - An Object containing the error data
 - **`data: Object`** - One (or more) Object containing additional data
 
-### fetchVAST(url, wrapperDepth = 0, previousUrl = null, ad = null)
+### fetchVAST(url, wrapperDepth = 0, previousUrl = null, wrapperAd = null)
 
 Fetches a VAST document for the given url. Returns a `Promise` which resolves with the fetched xml or rejects with an error, according to the result of the request.
 
@@ -225,7 +225,7 @@ Fetches a VAST document for the given url. Returns a `Promise` which resolves wi
 - **`url: String`** - The url to request the VAST document
 - **`wrapperDepth: Number`** - Number of wrappers that have occurred
 - **`previousUrl: String`** - The url of the previous VAST
-- **`ad: Ad`** - Previously parsed ad node (Wrapper) related to this fetching.
+- **`wrapperAd: Ad`** - Previously parsed ad node (Wrapper) related to this fetching.
 
 #### Events emitted
 

--- a/docs/api/vast-parser.md
+++ b/docs/api/vast-parser.md
@@ -87,6 +87,7 @@ Event is triggered when `fetchVAST` function is called, before the fetching star
 - `wrapperDepth: Number`
 - `maxWrapperDepth: Number`
 - `timeout: Number`
+- `ad: Ad`
 
 ```Javascript
 vastParser.on('VAST-resolving', ({ url, wrapperDepth, previousUrl }) => {
@@ -215,7 +216,7 @@ Tracks the error provided in the errorCode parameter and emits a `VAST-error` ev
 - **`errorCode: Object`** - An Object containing the error data
 - **`data: Object`** - One (or more) Object containing additional data
 
-### fetchVAST(url, wrapperDepth = 0, previousUrl = null)
+### fetchVAST(url, wrapperDepth = 0, previousUrl = null, ad = null)
 
 Fetches a VAST document for the given url. Returns a `Promise` which resolves with the fetched xml or rejects with an error, according to the result of the request.
 
@@ -224,6 +225,7 @@ Fetches a VAST document for the given url. Returns a `Promise` which resolves wi
 - **`url: String`** - The url to request the VAST document
 - **`wrapperDepth: Number`** - Number of wrappers that have occurred
 - **`previousUrl: String`** - The url of the previous VAST
+- **`ad: Ad`** - Previously parsed ad node (Wrapper) related to this fetching.
 
 #### Events emitted
 

--- a/spec/vast_parser.spec.js
+++ b/spec/vast_parser.spec.js
@@ -101,7 +101,7 @@ describe('VASTParser', () => {
             wrapperDepth: 2,
             maxWrapperDepth: 8,
             timeout: 120000,
-            ad,
+            wrapperAd: ad,
           });
 
           expect(VastParser.emit).toHaveBeenNthCalledWith(2, 'VAST-resolved', {
@@ -169,7 +169,7 @@ describe('VASTParser', () => {
                 wrapperDepth: 2,
                 maxWrapperDepth: 8,
                 timeout: 120000,
-                ad,
+                wrapperAd: ad,
               }
             );
 
@@ -304,7 +304,7 @@ describe('VASTParser', () => {
                   wrapperDepth: 0,
                   maxWrapperDepth: 8,
                   timeout: 120000,
-                  ad: expect.any(Object),
+                  wrapperAd: expect.any(Object),
                 },
               ],
               [
@@ -347,7 +347,7 @@ describe('VASTParser', () => {
                   wrapperDepth: 1,
                   maxWrapperDepth: 8,
                   timeout: 120000,
-                  ad: expect.any(Object),
+                  wrapperAd: expect.any(Object),
                 },
               ],
               // RESOLVING AD 2 (WRAPPER VPAID) IN WRAPPER A
@@ -359,7 +359,7 @@ describe('VASTParser', () => {
                   wrapperDepth: 1,
                   maxWrapperDepth: 8,
                   timeout: 120000,
-                  ad: expect.any(Object),
+                  wrapperAd: expect.any(Object),
                 },
               ],
               // AD 1 (WRAPPER B) IN WRAPPER A
@@ -393,7 +393,7 @@ describe('VASTParser', () => {
                   wrapperDepth: 2,
                   maxWrapperDepth: 8,
                   timeout: 120000,
-                  ad: expect.any(Object),
+                  wrapperAd: expect.any(Object),
                 },
               ],
               // AD 2 (WRAPPER VPAID) IN WRAPPER A

--- a/spec/vast_parser.spec.js
+++ b/spec/vast_parser.spec.js
@@ -27,6 +27,25 @@ const wrapperWithAttributesVastUrl = urlFor(
 );
 const wrapperInvalidVastUrl = urlFor('wrapper-invalid-xmlfile.xml');
 const vastWithErrorUrl = urlFor('empty-no-ad.xml');
+const ad = {
+  id: null,
+  sequence: 1,
+  system: { value: 'VAST', version: null },
+  title: null,
+  description: null,
+  advertiser: null,
+  pricing: null,
+  survey: null,
+  errorURLTemplates: ['http://example.com/wrapperA-error'],
+  impressionURLTemplates: [],
+  creatives: [],
+  extensions: [],
+  adVerifications: [],
+  trackingEvents: { nonlinear: [], linear: [] },
+  videoClickTrackingURLTemplates: [],
+  videoCustomClickURLTemplates: [],
+  viewableImpression: [],
+};
 
 describe('VASTParser', () => {
   let VastParser;
@@ -73,7 +92,8 @@ describe('VASTParser', () => {
         return VastParser.fetchVAST(
           'www.foo.foo',
           2,
-          'www.original.foo'
+          'www.original.foo',
+          ad
         ).finally(() => {
           expect(VastParser.emit).toHaveBeenNthCalledWith(1, 'VAST-resolving', {
             url: 'www.foo.foo',
@@ -81,6 +101,7 @@ describe('VASTParser', () => {
             wrapperDepth: 2,
             maxWrapperDepth: 8,
             timeout: 120000,
+            ad,
           });
 
           expect(VastParser.emit).toHaveBeenNthCalledWith(2, 'VAST-resolved', {
@@ -134,7 +155,7 @@ describe('VASTParser', () => {
       });
 
       it('emits VAST-resolving and VAST-resolved events', () => {
-        return VastParser.fetchVAST('www.foo.foo', 2, 'www.original.foo')
+        return VastParser.fetchVAST('www.foo.foo', 2, 'www.original.foo', ad)
           .then(() => {
             expect(true).toBeFalsy();
           })
@@ -148,6 +169,7 @@ describe('VASTParser', () => {
                 wrapperDepth: 2,
                 maxWrapperDepth: 8,
                 timeout: 120000,
+                ad,
               }
             );
 
@@ -256,10 +278,10 @@ describe('VASTParser', () => {
           expect(VastParser.fetchVAST.mock.calls).toEqual(
             expect.arrayContaining([
               [wrapperAVastUrl],
-              [wrapperBVastUrl, 1, wrapperAVastUrl],
-              [inlineVpaidVastUrl, 1, wrapperAVastUrl],
-              [inlineSampleVastUrl, 2, wrapperBVastUrl],
-              [inlineSampleVastUrl, 2, wrapperBVastUrl],
+              [wrapperBVastUrl, 1, wrapperAVastUrl, expect.any(Object)],
+              [inlineVpaidVastUrl, 1, wrapperAVastUrl, expect.any(Object)],
+              [inlineSampleVastUrl, 2, wrapperBVastUrl, expect.any(Object)],
+              [inlineSampleVastUrl, 2, wrapperBVastUrl, expect.any(Object)],
             ])
           );
         });
@@ -282,6 +304,7 @@ describe('VASTParser', () => {
                   wrapperDepth: 0,
                   maxWrapperDepth: 8,
                   timeout: 120000,
+                  ad: expect.any(Object),
                 },
               ],
               [
@@ -324,6 +347,7 @@ describe('VASTParser', () => {
                   wrapperDepth: 1,
                   maxWrapperDepth: 8,
                   timeout: 120000,
+                  ad: expect.any(Object),
                 },
               ],
               // RESOLVING AD 2 (WRAPPER VPAID) IN WRAPPER A
@@ -335,6 +359,7 @@ describe('VASTParser', () => {
                   wrapperDepth: 1,
                   maxWrapperDepth: 8,
                   timeout: 120000,
+                  ad: expect.any(Object),
                 },
               ],
               // AD 1 (WRAPPER B) IN WRAPPER A
@@ -368,6 +393,7 @@ describe('VASTParser', () => {
                   wrapperDepth: 2,
                   maxWrapperDepth: 8,
                   timeout: 120000,
+                  ad: expect.any(Object),
                 },
               ],
               // AD 2 (WRAPPER VPAID) IN WRAPPER A
@@ -805,7 +831,8 @@ describe('VASTParser', () => {
           expect(VastParser.fetchVAST).toHaveBeenCalledWith(
             wrapperBVastUrl,
             1,
-            wrapperAVastUrl
+            wrapperAVastUrl,
+            adWithWrapper,
           );
           expect(VastParser.parse).toHaveBeenCalledWith(expect.any(Object), {
             url: wrapperBVastUrl,
@@ -832,7 +859,8 @@ describe('VASTParser', () => {
           expect(VastParser.fetchVAST).toHaveBeenCalledWith(
             wrapperBVastUrl,
             1,
-            wrapperAVastUrl
+            wrapperAVastUrl,
+            adWithWrapper
           );
           expect(VastParser.parse).not.toHaveBeenCalled();
           expect(parserUtils.mergeWrapperAdData).not.toBeCalled();

--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -108,13 +108,14 @@ export class VASTParser extends EventEmitter {
    * Fetches a VAST document for the given url.
    * Returns a Promise which resolves,rejects according to the result of the request.
    * @param  {String} url - The url to request the VAST document.
-   * @param {Number} wrapperDepth - how many times the current url has been wrapped
-   * @param {String} previousUrl - url of the previous VAST
+   * @param {Number} wrapperDepth - How many times the current url has been wrapped.
+   * @param {String} previousUrl - Url of the previous VAST.
+   * @param {Object} ad - Previously parsed ad node (Wrapper) related to this fetching.
    * @emits  VASTParser#VAST-resolving
    * @emits  VASTParser#VAST-resolved
    * @return {Promise}
    */
-  fetchVAST(url, wrapperDepth = 0, previousUrl = null) {
+  fetchVAST(url, wrapperDepth = 0, previousUrl = null, ad = null) {
     return new Promise((resolve, reject) => {
       // Process url with defined filter
       this.URLTemplateFilters.forEach((filter) => {
@@ -129,6 +130,7 @@ export class VASTParser extends EventEmitter {
         wrapperDepth,
         maxWrapperDepth: this.maxWrapperDepth,
         timeout: this.fetchingOptions.timeout,
+        ad,
       });
 
       this.urlHandler.get(
@@ -520,7 +522,7 @@ export class VASTParser extends EventEmitter {
         this.parsingOptions.allowMultipleAds ?? ad.allowMultipleAds;
       // sequence doesn't carry over in wrapper element
       const wrapperSequence = ad.sequence;
-      this.fetchVAST(ad.nextWrapperURL, wrapperDepth, previousUrl)
+      this.fetchVAST(ad.nextWrapperURL, wrapperDepth, previousUrl, ad)
         .then((xml) => {
           return this.parse(xml, {
             url: ad.nextWrapperURL,

--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -110,12 +110,12 @@ export class VASTParser extends EventEmitter {
    * @param  {String} url - The url to request the VAST document.
    * @param {Number} wrapperDepth - How many times the current url has been wrapped.
    * @param {String} previousUrl - Url of the previous VAST.
-   * @param {Object} ad - Previously parsed ad node (Wrapper) related to this fetching.
+   * @param {Object} wrapperAd - Previously parsed ad node (Wrapper) related to this fetching.
    * @emits  VASTParser#VAST-resolving
    * @emits  VASTParser#VAST-resolved
    * @return {Promise}
    */
-  fetchVAST(url, wrapperDepth = 0, previousUrl = null, ad = null) {
+  fetchVAST(url, wrapperDepth = 0, previousUrl = null, wrapperAd = null) {
     return new Promise((resolve, reject) => {
       // Process url with defined filter
       this.URLTemplateFilters.forEach((filter) => {
@@ -130,7 +130,7 @@ export class VASTParser extends EventEmitter {
         wrapperDepth,
         maxWrapperDepth: this.maxWrapperDepth,
         timeout: this.fetchingOptions.timeout,
-        ad,
+        wrapperAd,
       });
 
       this.urlHandler.get(


### PR DESCRIPTION
### Description

In order to troubleshoot ad performances, we need to have some information on the current ad node being resolved 

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
