### PR TITLE
[breaking-change] add safeguards to public methods

### DIFF
--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -226,11 +226,13 @@ describe('VASTTracker', function () {
     });
 
     describe('#setDuration', () => {
-      it('should return undefined for invalid duration input',  () => {
-        const invalidDuration = 'aint a valid duration';
-        expect(vastTracker.setDuration(invalidDuration)).toBeUndefined();
-      })
-    })
+      it('should update assetDuration with the given value',  () => {
+        const newDuration = 123;
+        vastTracker.assetDuration = null;
+        vastTracker.setDuration(newDuration);
+        expect(vastTracker.assetDuration).toEqual(123);
+      });
+    });
 
     describe('#setProgress', () => {
       beforeEach(() => {
@@ -254,10 +256,6 @@ describe('VASTTracker', function () {
           ['progress-4%', expect.anything()]
         );
       });
-      it('should return undefined for invalid progress input',  () => {
-        const invalidParam = 'aint a valid progress';
-        expect(vastTracker.setProgress(invalidParam)).toBeUndefined();
-      })
     });
 
     describe('#isQuartileReached', () => {
@@ -270,9 +268,11 @@ describe('VASTTracker', function () {
     })
 
     describe('#setSkipDelay', () => {
-      it('should return undefined for invalid duration input',  () => {
-        const invalidDuration = 'aint a valid duration';
-        expect(vastTracker.setSkipDelay(invalidDuration)).toBeUndefined();
+      it('should update skipDelay value to the given value',  () => {
+        const newSkipDelay = 123;
+        vastTracker.skipDelay = null;
+        vastTracker.setSkipDelay(newSkipDelay);
+        expect(vastTracker.skipDelay).toEqual(123);
       })
     });
 

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -261,11 +261,11 @@ describe('VASTTracker', function () {
     });
 
     describe('#isQuartileReached', () => {
-      it('should return false for invalid quartile input', () => {
-        const time = 0;
-        const progress = 0;
-        const invalidQuartile = 'aint a valid quartile';
-        expect(vastTracker.isQuartileReached(invalidParam, time, progress)).toBeFalsy();
+      it('should return true when the given quartile has been reached', () => {
+        const time = 20;
+        const progress = 30;
+        const quartile = 'midpoint';
+        expect(vastTracker.isQuartileReached(quartile, time, progress)).toBeTruthy();
       })
     })
 
@@ -306,6 +306,15 @@ describe('VASTTracker', function () {
         vastTracker.trackImpression(macros);
         expect(spyTrackUrl).not.toHaveBeenCalledTimes(2);
         expect(spyTrack).not.toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('#convertToTimecode', () => {
+      it('should return the formatted time string', () => {
+        const timeInSeconds = 3600 + 1200 + 36 + 0.123; // 1h + 20min + 36sec + 0.123ms
+        const expectedResult = '01:20:36.123';
+        const result = vastTracker.convertToTimecode(timeInSeconds);
+        expect(result).toEqual(expectedResult);
       });
     });
 

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -225,7 +225,14 @@ describe('VASTTracker', function () {
       });
     });
 
-    describe('setProgress', () => {
+    describe('#setDuration', () => {
+      it('should return undefined for invalid duration input',  () => {
+        const invalidDuration = 'aint a valid duration';
+        expect(vastTracker.setDuration(invalidDuration)).toBeUndefined();
+      })
+    })
+
+    describe('#setProgress', () => {
       beforeEach(() => {
         vastTracker.assetDuration = 10;
         vastTracker.setProgress(5);
@@ -247,6 +254,26 @@ describe('VASTTracker', function () {
           ['progress-4%', expect.anything()]
         );
       });
+      it('should return undefined for invalid progress input',  () => {
+        const invalidParam = 'aint a valid progress';
+        expect(vastTracker.setProgress(invalidParam)).toBeUndefined();
+      })
+    });
+
+    describe('#isQuartileReached', () => {
+      it('should return false for invalid quartile input', () => {
+        const time = 0;
+        const progress = 0;
+        const invalidQuartile = 'aint a valid quartile';
+        expect(vastTracker.isQuartileReached(invalidParam, time, progress)).toBeFalsy();
+      })
+    })
+
+    describe('#setSkipDelay', () => {
+      it('should return undefined for invalid duration input',  () => {
+        const invalidDuration = 'aint a valid duration';
+        expect(vastTracker.setSkipDelay(invalidDuration)).toBeUndefined();
+      })
     });
 
     describe('#trackImpression', () => {

--- a/src/util/event_emitter.js
+++ b/src/util/event_emitter.js
@@ -60,7 +60,7 @@ export class EventEmitter {
    * Synchronously calls each of the handlers registered for the named event,
    * in the order they were registered, passing the supplied arguments to each.
    * @param {String} event
-   * @param  {any[]} args
+   * @param  {...any} args list of arguments that will be used by the event handler
    * @returns {Boolean} true if the event had handlers, false otherwise.
    */
   emit(event, ...args) {

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -32,9 +32,7 @@ function resolveURLTemplates(URLTemplates, macros = {}, options = {}) {
   }
 
   // Calc random/time based macros
-  macros['CACHEBUSTING'] = addLeadingZeros(
-    Math.round(Math.random() * 1.0e8).toString()
-  );
+  macros['CACHEBUSTING'] = addLeadingZeros(Math.round(Math.random() * 1.0e8));
   macros['TIMESTAMP'] = new Date().toISOString();
 
   // RANDOM/random is not defined in VAST 3/4 as a valid macro tho it's used by some adServer (Auditude)
@@ -180,10 +178,11 @@ function encodeURIComponentRFC3986(str) {
  *
  * @param {Number} input - number to convert
  * @param {Number} length - length of the desired string
+ *
+ * @return {String}
  */
 function addLeadingZeros(input, length = 8) {
-  const additionalZerosCount = Math.max(0, length - input.toString().length);
-  return '0'.repeat(additionalZerosCount) + input.toString();
+  return input.toString().padStart(length, '0');
 }
 
 function isNumeric(n) {
@@ -221,9 +220,9 @@ function joinArrayOfUniqueTemplateObjs(arr1 = [], arr2 = []) {
 
 /**
  * Check if a provided value is a valid time value according to the IAB definition
+ * Check if a provided value is a valid time value according to the IAB definition: Must be a positive number or -1.
+ * if not implemented by ad unit or -2 if value is unknown.
  * @param {Number} time
- * According to IAB, if a value is not implemented, the ad unit returns a -1 value.
- * If the value is unknown, the ad unit returns a -2.
  *
  * @return {Boolean}
  */

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -32,7 +32,7 @@ function resolveURLTemplates(URLTemplates, macros = {}, options = {}) {
   }
 
   // Calc random/time based macros
-  macros['CACHEBUSTING'] = leftpad(
+  macros['CACHEBUSTING'] = addLeadingZeros(
     Math.round(Math.random() * 1.0e8).toString()
   );
   macros['TIMESTAMP'] = new Date().toISOString();
@@ -175,27 +175,15 @@ function encodeURIComponentRFC3986(str) {
   );
 }
 
-function leftpad(input, len = 8) {
-  const str = String(input);
-  if (str.length < len) {
-    return (
-      range(0, len - str.length, false)
-        .map(() => '0')
-        .join('') + str
-    );
-  }
-  return str;
-}
-
-function range(left, right, inclusive) {
-  const result = [];
-  const ascending = left < right;
-  const end = !inclusive ? right : ascending ? right + 1 : right - 1;
-
-  for (let i = left; ascending ? i < end : i > end; ascending ? i++ : i--) {
-    result.push(i);
-  }
-  return result;
+/**
+ * Return a string of the input number with leading zeros defined by the length param
+ *
+ * @param {Number} input - number to convert
+ * @param {Number} length - length of the desired string
+ */
+function addLeadingZeros(input, length = 8) {
+  const additionalZerosCount = Math.max(0, length - input.toString().length);
+  return '0'.repeat(additionalZerosCount) + input.toString();
 }
 
 function isNumeric(n) {
@@ -251,10 +239,9 @@ export const util = {
   isTemplateObjectEqual,
   encodeURIComponentRFC3986,
   replaceUrlMacros,
-  leftpad,
-  range,
   isNumeric,
   flatten,
   joinArrayOfUniqueTemplateObjs,
   isValidTimeValue,
+  addLeadingZeros,
 };

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -231,6 +231,18 @@ function joinArrayOfUniqueTemplateObjs(arr1 = [], arr2 = []) {
   }, []);
 }
 
+/**
+ * Check if a provided value is a valid time value according to the IAB definition
+ * @param {Number} time
+ * According to IAB, if a value is not implemented, the ad unit returns a -1 value.
+ * If the value is unknown, the ad unit returns a -2.
+ *
+ * @return {Boolean}
+ */
+function isValidTimeValue(time) {
+  return Number.isFinite(time) && time >= -2
+}
+
 export const util = {
   track,
   resolveURLTemplates,
@@ -244,4 +256,5 @@ export const util = {
   isNumeric,
   flatten,
   joinArrayOfUniqueTemplateObjs,
+  isValidTimeValue,
 };

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -185,10 +185,10 @@ export class VASTTracker extends EventEmitter {
 
     if (skipDelay !== -1 && !this.skippable) {
       if (skipDelay > progress) {
-        this.emit('skip-countdown', [skipDelay - progress]);
+        this.emit('skip-countdown', skipDelay - progress);
       } else {
         this.skippable = true;
-        this.emit('skip-countdown', [0]);
+        this.emit('skip-countdown', 0);
       }
     }
 
@@ -688,15 +688,18 @@ export class VASTTracker extends EventEmitter {
    * @return {String}
    */
   convertToTimecode(timeInSeconds) {
-    const formattedMs = `${util.addLeadingZeros((timeInSeconds * 1000) % 1000, 3)}`;
-    return`${new Date(Date.UTC(
-      1970,
-      0,
-      1,
-      0,
-      new Date(0).getTimezoneOffset(),
-      timeInSeconds)
-    ).toLocaleTimeString("en-GB", {hour12: false})}.${formattedMs}`;
+    // Get the locale timezone offset in milliseconds
+    const timezoneOffsetInMs = new Date(timeInSeconds * 1000).getTimezoneOffset() * 60 * 1000;
+
+    // Create a date object from timeInSeconds
+    // Delete the timezone offset so that, new Date(0) => 00:00:00 regardless of the locale
+    // Shape the datetime object in a hh:mm:ss 24h format
+    const formattedTime =  new Date((timeInSeconds * 1000) + timezoneOffsetInMs).toLocaleTimeString('en-GB');
+
+    // Get milliseconds and leading zeros if needed.
+    const formattedMs = util.addLeadingZeros((timeInSeconds * 1000) % 1000, 3);
+
+    return `${formattedTime}.${formattedMs}`
   }
 
   /**

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -178,7 +178,7 @@ export class VASTTracker extends EventEmitter {
    */
   setProgress(progress, macros = {}) {
     // check if progress is a valid time input
-    if(!util.isValidTimeValue(progress)) {
+    if (!util.isValidTimeValue(progress) || typeof macros !== 'object') {
       return;
     }
     const skipDelay = this.skipDelay || DEFAULT_SKIP_DELAY;
@@ -250,7 +250,7 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#unmute
    */
   setMuted(muted, macros = {}) {
-    if (typeof muted !== 'boolean') {
+    if (typeof muted !== 'boolean' || typeof macros !== 'object') {
       return;
     }
     if (this.muted !== muted) {
@@ -268,7 +268,7 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#resume
    */
   setPaused(paused, macros = {}) {
-    if (typeof paused !== 'boolean') {
+    if (typeof paused !== 'boolean' || typeof macros !== 'object') {
       return;
     }
     if (this.paused !== paused) {
@@ -286,7 +286,7 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#exitFullscreen
    */
   setFullscreen(fullscreen, macros = {}) {
-    if (typeof fullscreen !== 'boolean') {
+    if (typeof fullscreen !== 'boolean' || typeof macros !== 'object') {
       return;
     }
     if (this.fullscreen !== fullscreen) {
@@ -306,7 +306,7 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#playerCollapse
    */
   setExpand(expanded, macros = {}) {
-    if (typeof expanded !== 'boolean') {
+    if (typeof expanded !== 'boolean' || typeof macros !== 'object') {
       return;
     }
     if (this.expanded !== expanded) {
@@ -325,7 +325,7 @@ export class VASTTracker extends EventEmitter {
    * @param {Number} duration - The time in seconds until the skip button is displayed.
    */
   setSkipDelay(duration) {
-    if(!util.isValidTimeValue(duration)) {
+    if (!util.isValidTimeValue(duration)) {
       return;
     }
     this.skipDelay = duration;
@@ -337,6 +337,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#creativeView
    */
   trackImpression(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     if (!this.impressed) {
       this.impressed = true;
       this.trackURLs(this.ad.impressionURLTemplates, macros);
@@ -350,6 +353,9 @@ export class VASTTracker extends EventEmitter {
    * @param {Boolean} [isCustomCode=false] - Flag to allow custom values on error code.
    */
   error(macros = {}, isCustomCode = false) {
+    if (typeof macros !== 'object' || typeof isCustomCode !== 'boolean') {
+      return;
+    }
     this.trackURLs(this.ad.errorURLTemplates, macros, { isCustomCode });
   }
 
@@ -361,6 +367,9 @@ export class VASTTracker extends EventEmitter {
    * @param {Boolean} [isCustomCode=false] - Flag to allow custom values on error code.
    */
   errorWithCode(errorCode, isCustomCode = false) {
+    if (typeof errorCode !== 'string' || typeof isCustomCode !== 'boolean') {
+      return;
+    }
     this.error({ ERRORCODE: errorCode }, isCustomCode);
     //eslint-disable-next-line
     console.log(
@@ -376,6 +385,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#complete
    */
   complete(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track('complete', { macros });
   }
 
@@ -388,6 +400,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#notUsed
    */
   notUsed(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track('notUsed', { macros });
     this.trackingEvents = [];
   }
@@ -402,6 +417,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#otherAdInteraction
    */
   otherAdInteraction(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track('otherAdInteraction', { macros });
   }
 
@@ -416,6 +434,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#acceptInvitation
    */
   acceptInvitation(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track('acceptInvitation', { macros });
   }
 
@@ -427,6 +448,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#adExpand
    */
   adExpand(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track('adExpand', { macros });
   }
 
@@ -438,6 +462,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#adCollapse
    */
   adCollapse(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track('adCollapse', { macros });
   }
 
@@ -449,6 +476,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#minimize
    */
   minimize(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track('minimize', { macros });
   }
 
@@ -462,6 +492,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#verificationNotExecuted
    */
   verificationNotExecuted(vendor, macros = {}) {
+    if (typeof vendor !== 'string' || typeof macros !== 'object') {
+      return;
+    }
     if (
       !this.ad ||
       !this.ad.adVerifications ||
@@ -509,7 +542,7 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#overlayViewDuration
    */
   overlayViewDuration(formattedDuration, macros = {}) {
-    if (typeof formattedDuration !== 'string') {
+    if (typeof formattedDuration !== 'string' || typeof macros !== 'object') {
       return;
     }
     macros['ADPLAYHEAD'] = formattedDuration;
@@ -525,6 +558,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#close
    */
   close(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track(this.linear ? 'closeLinear' : 'close', { macros });
   }
 
@@ -535,6 +571,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#skip
    */
   skip(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track('skip', { macros });
   }
 
@@ -547,6 +586,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#loaded
    */
   load(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     this.track('loaded', { macros });
   }
 
@@ -560,6 +602,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#clickthrough
    */
   click(fallbackClickThroughURL = null, macros = {}) {
+    if ((fallbackClickThroughURL !== null && typeof fallbackClickThroughURL !== 'string') || typeof macros !== 'object') {
+      return;
+    }
     if (
       this.clickTrackingURLTemplates &&
       this.clickTrackingURLTemplates.length
@@ -595,6 +640,9 @@ export class VASTTracker extends EventEmitter {
    *
    */
   track(eventName, { macros = {}, once = false } = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
     // closeLinear event was introduced in VAST 3.0
     // Fallback to vast 2.0 close event if necessary
     if (
@@ -688,18 +736,18 @@ export class VASTTracker extends EventEmitter {
    * @return {String}
    */
   convertToTimecode(timeInSeconds) {
-    // Get the locale timezone offset in milliseconds
-    const timezoneOffsetInMs = new Date(timeInSeconds * 1000).getTimezoneOffset() * 60 * 1000;
-
-    // Create a date object from timeInSeconds
-    // Delete the timezone offset so that, new Date(0) => 00:00:00 regardless of the locale
-    // Shape the datetime object in a hh:mm:ss 24h format
-    const formattedTime =  new Date((timeInSeconds * 1000) + timezoneOffsetInMs).toLocaleTimeString('en-GB');
-
-    // Get milliseconds and leading zeros if needed.
-    const formattedMs = util.addLeadingZeros((timeInSeconds * 1000) % 1000, 3);
-
-    return `${formattedTime}.${formattedMs}`
+    if (!util.isValidTimeValue(timeInSeconds)) {
+      return '';
+    }
+    const progress = timeInSeconds * 1000;
+    const hours = Math.floor(progress / (60 * 60 * 1000));
+    const minutes = Math.floor((progress / (60 * 1000)) % 60);
+    const seconds = Math.floor((progress / 1000) % 60);
+    const milliseconds = Math.floor(progress % 1000);
+    return `${util.addLeadingZeros(hours, 2)}:${util.addLeadingZeros(
+      minutes,
+      2
+    )}:${util.addLeadingZeros(seconds, 2)}.${util.addLeadingZeros(milliseconds, 3)}`;
   }
 
   /**

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -227,7 +227,7 @@ export class VASTTracker extends EventEmitter {
    * Checks if a quartile has been reached without have being triggered already.
    *
    * @param {String} quartile - Quartile name
-   * @param {Number} time - Time offset, when this quartile is reached in seconds.
+   * @param {Number} time - Time offset of the quartile, when this quartile is reached in seconds.
    * @param {Number} progress - Current progress of the ads in seconds.
    *
    * @return {Boolean}
@@ -504,15 +504,15 @@ export class VASTTracker extends EventEmitter {
    * The time will be passed using [ADPLAYHEAD] macros for VAST 4.1
    * Calls the overlayViewDuration tracking URLs.
    *
-   * @param {String} duration - The time that the initial ad is displayed.
+   * @param {String} formattedDuration - The time that the initial ad is displayed.
    * @param {Object} [macros={}] - An optional Object containing macros and their values to be used and replaced in the tracking calls.
    * @emits VASTTracker#overlayViewDuration
    */
-  overlayViewDuration(duration, macros = {}) {
-    if (!util.isValidTimeValue(duration)) {
+  overlayViewDuration(formattedDuration, macros = {}) {
+    if (typeof formattedDuration !== 'string') {
       return;
     }
-    macros['ADPLAYHEAD'] = duration;
+    macros['ADPLAYHEAD'] = formattedDuration;
     this.track('overlayViewDuration', { macros });
   }
 
@@ -688,15 +688,15 @@ export class VASTTracker extends EventEmitter {
    * @return {String}
    */
   convertToTimecode(timeInSeconds) {
-    const progress = timeInSeconds * 1000;
-    const hours = Math.floor(progress / (60 * 60 * 1000));
-    const minutes = Math.floor((progress / (60 * 1000)) % 60);
-    const seconds = Math.floor((progress / 1000) % 60);
-    const milliseconds = Math.floor(progress % 1000);
-    return `${util.leftpad(hours, 2)}:${util.leftpad(
-      minutes,
-      2
-    )}:${util.leftpad(seconds, 2)}.${util.leftpad(milliseconds, 3)}`;
+    const formattedMs = `${util.addLeadingZeros((timeInSeconds * 1000) % 1000, 3)}`;
+    return`${new Date(Date.UTC(
+      1970,
+      0,
+      1,
+      0,
+      new Date(0).getTimezoneOffset(),
+      timeInSeconds)
+    ).toLocaleTimeString("en-GB", {hour12: false})}.${formattedMs}`;
   }
 
   /**

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -148,6 +148,10 @@ export class VASTTracker extends EventEmitter {
    * @param  {Number} duration - The duration of the ad.
    */
   setDuration(duration) {
+    // check if duration is a valid time input
+    if(!util.isValidTimeValue(duration)) {
+      return;
+    }
     this.assetDuration = duration;
     // beware of key names, theses are also used as event names
     this.quartiles = {
@@ -173,14 +177,18 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#thirdQuartile
    */
   setProgress(progress, macros = {}) {
+    // check if progress is a valid time input
+    if(!util.isValidTimeValue(progress)) {
+      return;
+    }
     const skipDelay = this.skipDelay || DEFAULT_SKIP_DELAY;
 
     if (skipDelay !== -1 && !this.skippable) {
       if (skipDelay > progress) {
-        this.emit('skip-countdown', skipDelay - progress);
+        this.emit('skip-countdown', [skipDelay - progress]);
       } else {
         this.skippable = true;
-        this.emit('skip-countdown', 0);
+        this.emit('skip-countdown', [0]);
       }
     }
 
@@ -242,6 +250,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#unmute
    */
   setMuted(muted, macros = {}) {
+    if (typeof muted !== 'boolean') {
+      return;
+    }
     if (this.muted !== muted) {
       this.track(muted ? 'mute' : 'unmute', { macros });
     }
@@ -257,6 +268,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#resume
    */
   setPaused(paused, macros = {}) {
+    if (typeof paused !== 'boolean') {
+      return;
+    }
     if (this.paused !== paused) {
       this.track(paused ? 'pause' : 'resume', { macros });
     }
@@ -272,6 +286,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#exitFullscreen
    */
   setFullscreen(fullscreen, macros = {}) {
+    if (typeof fullscreen !== 'boolean') {
+      return;
+    }
     if (this.fullscreen !== fullscreen) {
       this.track(fullscreen ? 'fullscreen' : 'exitFullscreen', { macros });
     }
@@ -289,6 +306,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#playerCollapse
    */
   setExpand(expanded, macros = {}) {
+    if (typeof expanded !== 'boolean') {
+      return;
+    }
     if (this.expanded !== expanded) {
       this.track(expanded ? 'expand' : 'collapse', { macros });
       this.track(expanded ? 'playerExpand' : 'playerCollapse', { macros });
@@ -305,9 +325,10 @@ export class VASTTracker extends EventEmitter {
    * @param {Number} duration - The time in seconds until the skip button is displayed.
    */
   setSkipDelay(duration) {
-    if (typeof duration === 'number') {
-      this.skipDelay = duration;
+    if(!util.isValidTimeValue(duration)) {
+      return;
     }
+    this.skipDelay = duration;
   }
 
   /**
@@ -488,6 +509,9 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#overlayViewDuration
    */
   overlayViewDuration(duration, macros = {}) {
+    if (!util.isValidTimeValue(duration)) {
+      return;
+    }
     macros['ADPLAYHEAD'] = duration;
     this.track('overlayViewDuration', { macros });
   }

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -283,7 +283,7 @@ describe('VASTTracker', function () {
         });
       });
 
-      describe('#errorWithCode', () => {
+      describe('#error', () => {
         before(() => {
           util.track = function (URLTemplates, variables, options) {
             _eventsSent.push(
@@ -296,7 +296,7 @@ describe('VASTTracker', function () {
         });
 
         it('should have called error urls with right code', () => {
-          this.Tracker.errorWithCode(405);
+          this.Tracker.error({ ERRORCODE: 405 });
           _eventsSent[0].should.eql([
             'http://example.com/wrapperA-error',
             'http://example.com/wrapperB-error',
@@ -305,7 +305,7 @@ describe('VASTTracker', function () {
         });
 
         it('should have called error urls with 900 if unknown code', () => {
-          this.Tracker.errorWithCode(10001);
+          this.Tracker.error({ ERRORCODE: 10001 });
           _eventsSent[0].should.eql([
             'http://example.com/wrapperA-error',
             'http://example.com/wrapperB-error',
@@ -314,7 +314,7 @@ describe('VASTTracker', function () {
         });
 
         it('should have called error urls with custom code when enabled', () => {
-          this.Tracker.errorWithCode(10001, true);
+          this.Tracker.error({ ERRORCODE: 10001 }, true);
           _eventsSent[0].should.eql([
             'http://example.com/wrapperA-error',
             'http://example.com/wrapperB-error',


### PR DESCRIPTION
### Description

Add safeguards to vast-tracker public methods according to IAB doc.

### Issue

Public methods of vast tracker are lacking security for input params. We need to make sure that the inputs type meets the IAB standards for every public method that we expose in the vast tracker.

### Type
- [x] Breaking change
- [ ] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
