### PR TITLE
Fix/add muted argument to constructor

### DIFF
--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -14,7 +14,7 @@ At key points during ad playback you will need to call thoses methods to fire co
 The constructor signature is:
 
 ```Javascript
-constructor(client, ad, creative, variation = null)
+constructor(client, ad, creative, variation = null, muted = false)
 ```
 
 #### Parameters
@@ -23,6 +23,7 @@ constructor(client, ad, creative, variation = null)
 - **`ad: Ad`** - The ad to track
 - **`creative: Creative`** - The creative to track
 - **`variation: CompanionAd|NonLinearAd`** - An optional variation of the creative, for Companion and NonLinear Ads
+- **`muted: Boolean`** - The initial muted state of the video. (optional, `false` by default)
 
 #### Example
 
@@ -39,6 +40,8 @@ const vastClient = new VASTClient();
 const vastTracker = new VASTTracker(vastClient, ad, creative);
 // For a companion ad
 const vastTracker = new VASTTracker(vastClient, ad, creative, companion);
+// With the initial muted state
+const vastTracker = new VASTTracker(vastClient, ad, creative, null, muted);
 
 // Without a client instance
 const vastTracker = new VASTTracker(null, ad, creative);
@@ -430,6 +433,8 @@ vastTracker.on('exitFullscreen', () => {
 ### setMuted(muted, macros) <a name="setMuted"></a>
 
 Updates the mute state and calls the mute/unmute tracking URLs.
+
+> :warning: setMuted is relying on an internal mute state, which is `unmuted` by default. If the initial mute state is `muted`, be sure to set it up when initializing the VASTTracker. Otherwise, the first unmute event will not be fired.
 
 #### Parameters
 

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -226,7 +226,7 @@ describe('VASTTracker', function () {
     });
 
     describe('#setDuration', () => {
-      it('should update assetDuration with the given value',  () => {
+      it('should update assetDuration with the given value', () => {
         const newDuration = 123;
         vastTracker.assetDuration = null;
         vastTracker.setDuration(newDuration);
@@ -263,17 +263,47 @@ describe('VASTTracker', function () {
         const time = 20;
         const progress = 30;
         const quartile = 'midpoint';
-        expect(vastTracker.isQuartileReached(quartile, time, progress)).toBeTruthy();
-      })
-    })
+        expect(
+          vastTracker.isQuartileReached(quartile, time, progress)
+        ).toBeTruthy();
+      });
+    });
+
+    describe('#setMuted', () => {
+      beforeEach(() => {
+        vastTracker.muted = false;
+      });
+      afterAll(() => {
+        vastTracker.muted = false;
+      });
+      it('Should emit mute tracker and update muted attribute when muted', () => {
+        vastTracker.setMuted(true);
+        expect(spyTrack).toHaveBeenCalledWith('mute', expect.anything());
+      });
+      it('Should emit unmute tracker and update muted attribute when unmuted', () => {
+        vastTracker.muted = true;
+        vastTracker.setMuted(false);
+        expect(spyTrack).toHaveBeenCalledWith('unmute', expect.anything());
+      });
+      it('Should not emit any tracker for same value', () => {
+        vastTracker.setMuted(false);
+        expect(spyTrack).not.toHaveBeenCalled();
+      });
+      it('Should not emit any tracker and not update muted attribute for invalid value', () => {
+        vastTracker.setMuted(null);
+        vastTracker.setMuted({ foo: 'bar' });
+        expect(spyTrack).not.toHaveBeenCalled();
+        expect(vastTracker.muted).toEqual(false);
+      });
+    });
 
     describe('#setSkipDelay', () => {
-      it('should update skipDelay value to the given value',  () => {
+      it('should update skipDelay value to the given value', () => {
         const newSkipDelay = 123;
         vastTracker.skipDelay = null;
         vastTracker.setSkipDelay(newSkipDelay);
         expect(vastTracker.skipDelay).toEqual(123);
-      })
+      });
     });
 
     describe('#trackImpression', () => {

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -26,7 +26,7 @@ export class VASTTracker extends EventEmitter {
    * @param {Ad} ad - The ad to track.
    * @param {Creative} creative - The creative to track.
    * @param {Object} [variation=null] - An optional variation of the creative.
-   * @param {boolean} [muted=false] - The initial muted state of the video.
+   * @param {Boolean} [muted=false] - The initial muted state of the video.
    * @constructor
    */
   constructor(client, ad, creative, variation = null, muted = false) {
@@ -150,7 +150,7 @@ export class VASTTracker extends EventEmitter {
    */
   setDuration(duration) {
     // check if duration is a valid time input
-    if(!util.isValidTimeValue(duration)) {
+    if (!util.isValidTimeValue(duration)) {
       return;
     }
     this.assetDuration = duration;
@@ -598,12 +598,16 @@ export class VASTTracker extends EventEmitter {
    * It calls the tracking URLs and emits a 'clickthrough' event with the resolved
    * clickthrough URL when done.
    *
-   * @param {String} [fallbackClickThroughURL=null] - an optional clickThroughURL template that could be used as a fallback
+   * @param {?String} [fallbackClickThroughURL=null] - an optional clickThroughURL template that could be used as a fallback
    * @param {Object} [macros={}] - An optional Object containing macros and their values to be used and replaced in the tracking calls.
    * @emits VASTTracker#clickthrough
    */
   click(fallbackClickThroughURL = null, macros = {}) {
-    if ((fallbackClickThroughURL !== null && typeof fallbackClickThroughURL !== 'string') || typeof macros !== 'object') {
+    if (
+      (fallbackClickThroughURL !== null &&
+        typeof fallbackClickThroughURL !== 'string') ||
+      typeof macros !== 'object'
+    ) {
       return;
     }
     if (
@@ -636,8 +640,9 @@ export class VASTTracker extends EventEmitter {
    * Calls the tracking URLs for the given eventName and emits the event.
    *
    * @param {String} eventName - The name of the event.
-   * @param {Object} [macros={}] - An optional Object of parameters(vast macros) to be used in the tracking calls.
-   * @param {Boolean} [once=false] - Boolean to define if the event has to be tracked only once.
+   * @param {Object} options
+   * @param {Object} [options.macros={}] - An optional Object of parameters(vast macros) to be used in the tracking calls.
+   * @param {Boolean} [options.once=false] - Boolean to define if the event has to be tracked only once.
    *
    */
   track(eventName, { macros = {}, once = false } = {}) {
@@ -748,7 +753,10 @@ export class VASTTracker extends EventEmitter {
     return `${util.addLeadingZeros(hours, 2)}:${util.addLeadingZeros(
       minutes,
       2
-    )}:${util.addLeadingZeros(seconds, 2)}.${util.addLeadingZeros(milliseconds, 3)}`;
+    )}:${util.addLeadingZeros(seconds, 2)}.${util.addLeadingZeros(
+      milliseconds,
+      3
+    )}`;
   }
 
   /**

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -26,14 +26,15 @@ export class VASTTracker extends EventEmitter {
    * @param {Ad} ad - The ad to track.
    * @param {Creative} creative - The creative to track.
    * @param {Object} [variation=null] - An optional variation of the creative.
+   * @param {boolean} [muted=false] - The initial muted state of the video.
    * @constructor
    */
-  constructor(client, ad, creative, variation = null) {
+  constructor(client, ad, creative, variation = null, muted = false) {
     super();
     this.ad = ad;
     this.creative = creative;
     this.variation = variation;
-    this.muted = false;
+    this.muted = muted;
     this.impressed = false;
     this.skippable = false;
     this.trackingEvents = {};


### PR DESCRIPTION
### Description

The `setMuted` method assumes that `muted` property is false by default.
Thus, the `unmute` tracking event will not fire if the player was in a muted state.

### Changes

This PR adds a way to provide initial mute state through constructor arguments.

### Type
- [ ] Breaking change
- [ ] Enhancement
- [x] Fix
- [ ] Documentation
- [ ] Tooling
