### PR TITLE
Fix/Validate URLTemplates before tracking

### DIFF
--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -39,6 +39,10 @@ export const inlineTrackersParsed = {
           id: 'sample-impression3',
           url: 'http://example.com/impression3_[RANDOM]',
         },
+        {
+          id: 'invalid-impression-url',
+          url: 'you_shall_not_path',
+        },
       ],
       creatives: [
         {

--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -37,7 +37,7 @@ export const inlineTrackersParsed = {
         },
         {
           id: 'sample-impression3',
-          url: 'http://example.com/impression3_[RANDOM]',
+          url: '//example.com/impression3_[RANDOM]',
         },
         {
           id: 'invalid-impression-url',

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -1,6 +1,7 @@
 import { VASTClient } from '../src/vast_client';
 import { VASTTracker } from '../src/vast_tracker';
 import { inlineTrackersParsed } from '../spec/samples/inline_trackers';
+import { util } from '../src/util/util';
 
 const vastClient = new VASTClient();
 
@@ -336,6 +337,26 @@ describe('VASTTracker', function () {
         vastTracker.trackImpression(macros);
         expect(spyTrackUrl).not.toHaveBeenCalledTimes(2);
         expect(spyTrack).not.toHaveBeenCalledTimes(2);
+      });
+
+      it('should skip invalid urls', () => {
+        const expectedUrlTemplates = [
+          {
+            id: 'sample-impression1',
+            url: 'http://example.com/impression1_asset:[ASSETURI]_[CACHEBUSTING]',
+          },
+          {
+            id: 'sample-impression2',
+            url: 'http://example.com/impression2_[random]',
+          },
+          {
+            id: 'sample-impression3',
+            url: '//example.com/impression3_[RANDOM]',
+          }
+        ]
+        const spyUtilTrack = jest.spyOn(util, 'track');
+        vastTracker.trackURLs(ad.impressionURLTemplates);
+        expect(spyUtilTrack).toHaveBeenCalledWith(expectedUrlTemplates, expect.anything(), expect.anything());
       });
     });
 

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -125,6 +125,25 @@ function extractURLsFromTemplates(URLTemplates) {
 }
 
 /**
+ * Filter URLTemplates elements to keep only valid and safe URL templates.
+ *   To be valid, urls should:
+ *   - have the same protocol as the client
+ *   or
+ *   - be protocol-relative urls
+ *
+ * @param {String|String[]|Object[]} URLTemplates - A string|string[]|object[] of url templates.
+ */
+function filterValidUrlTemplates(URLTemplates) {
+  if (Array.isArray(URLTemplates)) {
+    return URLTemplates.filter(urlTemplate => {
+      const url = urlTemplate.hasOwnProperty('url') ? urlTemplate.url : urlTemplate;
+      return (url.startsWith(location.protocol) || url.startsWith('//'))
+    })
+  }
+  return (URLTemplates.startsWith(location.protocol) || URLTemplates.startsWith('//'));
+}
+
+/**
  * Returns a boolean after checking if the object exists in the array.
  *   true - if the object exists, false otherwise
  *
@@ -234,6 +253,7 @@ export const util = {
   track,
   resolveURLTemplates,
   extractURLsFromTemplates,
+  filterValidUrlTemplates,
   containsTemplateObject,
   isTemplateObjectEqual,
   encodeURIComponentRFC3986,

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -131,16 +131,21 @@ function extractURLsFromTemplates(URLTemplates) {
  *   or
  *   - be protocol-relative urls
  *
- * @param {String|String[]|Object[]} URLTemplates - A string|string[]|object[] of url templates.
+ * @param {Array} URLTemplates - A Array of string/object containing urls templates.
  */
 function filterValidUrlTemplates(URLTemplates) {
   if (Array.isArray(URLTemplates)) {
     return URLTemplates.filter(urlTemplate => {
       const url = urlTemplate.hasOwnProperty('url') ? urlTemplate.url : urlTemplate;
-      return (url.startsWith(location.protocol) || url.startsWith('//'))
+      return isValidUrl(url);
     })
   }
-  return (URLTemplates.startsWith(location.protocol) || URLTemplates.startsWith('//'));
+  return isValidUrl(URLTemplates);
+}
+
+function isValidUrl(url) {
+  const regex = /^(https?:\/\/|\/\/)/;
+  return regex.test(url);
 }
 
 /**

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -688,6 +688,7 @@ export class VASTTracker extends EventEmitter {
    * @param {Object} [options={}] - An optional Object of options to be used in the tracking calls.
    */
   trackURLs(URLTemplates, macros = {}, options = {}) {
+    const validUrlTemplates = util.filterValidUrlTemplates(URLTemplates)
     //Avoid mutating the object received in parameters.
     const givenMacros = { ...macros };
     if (this.linear) {
@@ -732,7 +733,7 @@ export class VASTTracker extends EventEmitter {
       }
     }
 
-    util.track(URLTemplates, givenMacros, options);
+    util.track(validUrlTemplates, givenMacros, options);
   }
 
   /**


### PR DESCRIPTION
### Description

Check and validate tracking urls before requesting them.

### Issue

Provided tracking urls are not always valid urls

### Type
- [ ] Breaking change
- [x] Enhancement
- [x] Fix
- [ ] Documentation
- [ ] Tooling
