### PR TITLE
Enhancement/methods to trigger viewable impression trackers

### DIFF
--- a/docs/api/class-reference.md
+++ b/docs/api/class-reference.md
@@ -204,9 +204,9 @@ This object represents a generic Creative. It's used as a parent object for more
 ## ViewableImpression<a name="viewable-impression"></a>
 
 - `id: String|null`
-- `viewable: Array<String>`
-- `notviewable: Array<String>`
-- `viewundetermined: Array<String>`
+- `Viewable: Array<String>`
+- `NotViewable: Array<String>`
+- `ViewUndetermined: Array<String>`
 
 ## BlockedAdCategories<a name="blocked-ad-categories"></a>
 

--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -122,6 +122,9 @@ video events. To trigger a tracker you will need to call the corresponding `VAST
 | [minimize](#minimize)                               | `<Tracking event="minimize">`                                                                                                                                                                 |
 | [overlayViewDuration](#overlayViewDuration)         | `<Tracking event="overlayViewDuration">`                                                                                                                                                      |
 | [verificationNotExecuted](#verificationNotExecuted) | `<Tracking event="verificationNotExecuted">`                                                                                                                                                  |
+| [trackViewableImpression](#trackViewableImpression) | `<Viewable>`|
+|[trackNotViewableImpression](#trackNotViewableImpression) | `<NotViewable>`|
+|[trackUndeterminedImpression](#trackUndeterminedImpression) | `<ViewUndetermined>`|
 
 ## Macros <a name="macros"></a>
 
@@ -568,6 +571,71 @@ player.on('canplay', () => {
 
 vastTracker.on('creativeView', () => {
   // impression tracking URLs have been called
+});
+```
+### trackViewableImpression(macros) <a name='trackViewableImpression'></a>
+
+Reports the viewable impression URI. Will report the following URI:
+
+- All `<Viewable>` URI from the `<InLine>` and `<Wrapper>` tracking elements
+
+This method can be call on any player events depending on your player logic. 
+
+#### Parameters
+
+- - **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+
+#### Example
+
+
+```Javascript
+// Bind an event listener to the player
+player.addEventListener('you_event_here', () => {
+  vastTracker.trackViewableImpression();
+});
+```
+
+### trackNotViewableImpression(macro) <a name='trackNotViewableImpression'></a>
+
+Reports the viewable impression URI. Will report the following URI:
+
+- All `<NotViewable>` URI from the `<InLine>` and `<Wrapper>` tracking elements
+
+This method can be call on any player events depending on your player logic. 
+
+#### Parameters
+
+- - **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+
+#### Example
+
+
+```Javascript
+// Bind an event listener to the player
+player.addEventListener('you_event_here', () => {
+  vastTracker.trackNotViewableImpression();
+});
+```
+
+### trackUndeterminedImpression(macro) <a name='trackUndeterminedImpression'></a>
+
+Reports the viewable impression URI. Will report the following URI:
+
+- All `<ViewUndetermined>` URI from the `<InLine>` and `<Wrapper>` tracking elements
+
+This method can be call on any player events depending on your player logic. 
+
+#### Parameters
+
+- - **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+
+#### Example
+
+
+```Javascript
+// Bind an event listener to the player
+player.addEventListener('you_event_here', () => {
+  vastTracker.trackUndeterminedImpression();
 });
 ```
 

--- a/spec/ad_parser.spec.js
+++ b/spec/ad_parser.spec.js
@@ -100,19 +100,19 @@ describe('AdParser', function () {
 
     it('gets viewableImpression values', () => {
       expect(ad.viewableImpression[0].id).toEqual('viewable_impression_id');
-      expect(ad.viewableImpression[0].viewable).toHaveLength(2);
-      expect(ad.viewableImpression[0].viewable).toEqual([
+      expect(ad.viewableImpression[0].Viewable).toHaveLength(2);
+      expect(ad.viewableImpression[0].Viewable).toEqual([
         'http://www.example.com/viewable_impression_1',
         'http://www.sample.com/viewable_impression_2',
       ]);
-      expect(ad.viewableImpression[0].notviewable).toHaveLength(3);
-      expect(ad.viewableImpression[0].notviewable).toEqual([
+      expect(ad.viewableImpression[0].NotViewable).toHaveLength(3);
+      expect(ad.viewableImpression[0].NotViewable).toEqual([
         'http://www.example.com/not_viewable_1',
         'http://www.sample.com/not_viewable_2',
         'http://www.sample.com/not_viewable_3',
       ]);
-      expect(ad.viewableImpression[0].viewundetermined).toHaveLength(1);
-      expect(ad.viewableImpression[0].viewundetermined).toEqual([
+      expect(ad.viewableImpression[0].ViewUndetermined).toHaveLength(1);
+      expect(ad.viewableImpression[0].ViewUndetermined).toEqual([
         'http://www.example.com/view_undetermined_1',
       ]);
     });
@@ -290,26 +290,26 @@ describe('AdParser', function () {
       expect(parsedViewableImpression.id).toEqual('viewable_impression');
     });
 
-    it('validate viewableImpression viewable array', () => {
-      expect(parsedViewableImpression.viewable.length).toEqual(2);
-      expect(parsedViewableImpression.viewable).toEqual([
+    it('validate viewableImpression Viewable array', () => {
+      expect(parsedViewableImpression.Viewable.length).toEqual(2);
+      expect(parsedViewableImpression.Viewable).toEqual([
         'http://www.example.com/viewable_impression_1',
         'http://www.sample.com/viewable_impression_2',
       ]);
     });
 
     it('validate viewableImpression notviewable array', () => {
-      expect(parsedViewableImpression.notviewable.length).toEqual(3);
-      expect(parsedViewableImpression.notviewable).toEqual([
+      expect(parsedViewableImpression.NotViewable.length).toEqual(3);
+      expect(parsedViewableImpression.NotViewable).toEqual([
         'http://www.example.com/not_viewable_1',
         'http://www.sample.com/not_viewable_2',
         'http://www.sample.com/not_viewable_3',
       ]);
     });
 
-    it('validate viewableImpression viewundetermined array', () => {
-      expect(parsedViewableImpression.viewundetermined.length).toEqual(1);
-      expect(parsedViewableImpression.viewundetermined).toEqual([
+    it('validate viewableImpression ViewUndetermined array', () => {
+      expect(parsedViewableImpression.ViewUndetermined.length).toEqual(1);
+      expect(parsedViewableImpression.ViewUndetermined).toEqual([
         'http://www.example.com/view_undetermined_1',
       ]);
     });
@@ -318,15 +318,15 @@ describe('AdParser', function () {
       expect(parsedViewableImpressionPartial.id).toEqual(null);
     });
 
-    it('validate viewableImpressionPartial viewable array', () => {
-      expect(parsedViewableImpressionPartial.viewable.length).toEqual(1);
-      expect(parsedViewableImpressionPartial.viewable).toEqual([
+    it('validate viewableImpressionPartial Viewable array', () => {
+      expect(parsedViewableImpressionPartial.Viewable.length).toEqual(1);
+      expect(parsedViewableImpressionPartial.Viewable).toEqual([
         'http://www.example.com/viewable_impression_1',
       ]);
     });
 
-    it('validate viewableImpressionPartial notviewable is undefined', () => {
-      expect(parsedViewableImpressionPartial.notviewable).toBeUndefined;
+    it('validate viewableImpressionPartial NotViewable is undefined', () => {
+      expect(parsedViewableImpressionPartial.NotNiewable).toBeUndefined;
     });
 
     it('validate viewableImpressionPartial viewundetermined is undefined', () => {

--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -10,6 +10,17 @@ export const inlineTrackersParsed = {
       description: 'Description text',
       advertiser: { id: 'advertiser-desc', value: 'Advertiser name' },
       pricing: { value: '1.09', model: 'CPM', currency: 'USD' },
+      viewableImpression: [
+        {
+          id: '3234256',
+          Viewable: [
+            'http://example.com/viewable',
+            'http://example.com/viewable2',
+          ],
+          NotViewable: ['http://example.com/notviewable'],
+          ViewUndetermined: ['http://example.com/undertermined'],
+        },
+      ],
       categories: [
         {
           authority: 'https://www.example.com/categoryauthority',

--- a/spec/vast_trackers.spec.js
+++ b/spec/vast_trackers.spec.js
@@ -352,11 +352,51 @@ describe('VASTTracker', function () {
           {
             id: 'sample-impression3',
             url: '//example.com/impression3_[RANDOM]',
-          }
-        ]
+          },
+        ];
         const spyUtilTrack = jest.spyOn(util, 'track');
         vastTracker.trackURLs(ad.impressionURLTemplates);
-        expect(spyUtilTrack).toHaveBeenCalledWith(expectedUrlTemplates, expect.anything(), expect.anything());
+        expect(spyUtilTrack).toHaveBeenCalledWith(
+          expectedUrlTemplates,
+          expect.anything(),
+          expect.anything()
+        );
+      });
+    });
+
+    describe('#viewableImpression', () => {
+      const macros = {
+        SERVERSIDE: '0',
+      };
+
+      describe('#trackViewableImpression', () => {
+        it('should call Viewable URLs', () => {
+          vastTracker.trackViewableImpression(macros);
+          expect(spyTrackUrl).toHaveBeenCalledWith(
+            ['http://example.com/viewable', 'http://example.com/viewable2'],
+            macros
+          );
+        });
+      });
+
+      describe('#trackNotViewableImpression', () => {
+        it('should call NotViewable URLs', () => {
+          vastTracker.trackNotViewableImpression(macros);
+          expect(spyTrackUrl).toHaveBeenCalledWith(
+            ['http://example.com/notviewable'],
+            macros
+          );
+        });
+      });
+
+      describe('#trackUndeterminedImpression', () => {
+        it('should call ViewUndetermined URLs', () => {
+          vastTracker.trackUndeterminedImpression(macros);
+          expect(spyTrackUrl).toHaveBeenCalledWith(
+            ['http://example.com/undertermined'],
+            macros
+          );
+        });
       });
     });
 

--- a/src/parser/ad_parser.js
+++ b/src/parser/ad_parser.js
@@ -389,34 +389,23 @@ export function _parseAdVerificationsFromExtensions(extensions) {
  */
 export function _parseViewableImpression(viewableImpressionNode) {
   const viewableImpression = {};
-  viewableImpression.id = viewableImpressionNode.getAttribute('id') || null;
-  const viewableImpressionChildNodes = viewableImpressionNode.childNodes;
-  for (const viewableImpressionElementKey in viewableImpressionChildNodes) {
-    const viewableImpressionElement =
-      viewableImpressionChildNodes[viewableImpressionElementKey];
-    const viewableImpressionNodeName = viewableImpressionElement.nodeName;
-    const viewableImpressionNodeValue = parserUtils.parseNodeText(
-      viewableImpressionElement
-    );
 
-    if (
-      (viewableImpressionNodeName !== 'Viewable' &&
-        viewableImpressionNodeName !== 'NotViewable' &&
-        viewableImpressionNodeName !== 'ViewUndetermined') ||
-      !viewableImpressionNodeValue
-    ) {
-      continue;
-    } else {
-      const viewableImpressionNodeNameLower =
-        viewableImpressionNodeName.toLowerCase();
-      if (!Array.isArray(viewableImpression[viewableImpressionNodeNameLower])) {
-        viewableImpression[viewableImpressionNodeNameLower] = [];
-      }
-      viewableImpression[viewableImpressionNodeNameLower].push(
-        viewableImpressionNodeValue
-      );
+  viewableImpression.id = viewableImpressionNode.getAttribute('id') || null;
+  const validNodes = ['Viewable', 'NotViewable', 'ViewUndetermined'];
+
+  const viewableImpressionChildNodes = [
+    ...viewableImpressionNode.childNodes,
+  ].filter((node) => validNodes.includes(node.nodeName));
+
+  validNodes.forEach((nodeName) => {
+    if (!Array.isArray(viewableImpression[nodeName])) {
+      viewableImpression[nodeName] = [];
     }
-  }
+  });
+
+  viewableImpressionChildNodes.forEach((node) => {
+    viewableImpression[node.nodeName].push(parserUtils.parseNodeText(node));
+  });
 
   return viewableImpression;
 }

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -349,6 +349,48 @@ export class VASTTracker extends EventEmitter {
   }
 
   /**
+   * Tracks Viewable impression
+   * @param {Object} [macros = {}] An optional Object containing macros and their values to be used and replaced in the tracking calls.
+   */
+  trackViewableImpression(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
+    this.ad.viewableImpression.forEach((impression) => {
+      this.trackURLs(impression.Viewable, macros);
+    });
+  }
+
+  /**
+   * Tracks NotViewable impression
+   * @param {Object} [macros = {}] An optional Object containing macros and their values to be used and replaced in the tracking calls.
+   */
+
+  trackNotViewableImpression(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
+
+    this.ad.viewableImpression.forEach((impression) => {
+      this.trackURLs(impression.NotViewable, macros);
+    });
+  }
+
+  /**
+   * Tracks ViewUndetermined impression
+   * @param {Object} [macros = {}] An optional Object containing macros and their values to be used and replaced in the tracking calls.
+   */
+  trackUndeterminedImpression(macros = {}) {
+    if (typeof macros !== 'object') {
+      return;
+    }
+
+    this.ad.viewableImpression.forEach((impression) => {
+      this.trackURLs(impression.ViewUndetermined, macros);
+    });
+  }
+
+  /**
    * Send a request to the URI provided by the VAST <Error> element.
    * @param {Object} [macros={}] - An optional Object containing macros and their values to be used and replaced in the tracking calls.
    * @param {Boolean} [isCustomCode=false] - Flag to allow custom values on error code.
@@ -688,7 +730,7 @@ export class VASTTracker extends EventEmitter {
    * @param {Object} [options={}] - An optional Object of options to be used in the tracking calls.
    */
   trackURLs(URLTemplates, macros = {}, options = {}) {
-    const validUrlTemplates = util.filterValidUrlTemplates(URLTemplates)
+    const validUrlTemplates = util.filterValidUrlTemplates(URLTemplates);
     //Avoid mutating the object received in parameters.
     const givenMacros = { ...macros };
     if (this.linear) {


### PR DESCRIPTION
### Description

Adding 3 public methods to track viewableImpression 
- trackViewableImpression() to report all `<Viewable>` URI
- trackNotViewableImpression() to report all `<notViewable>` URI
- trackUndeterminedImpression() to report all `<ViewableUndetermined>` URI

### Issue

The vastTracker did not provide any methods to track viewableImpression node

### Type
- [ ] Breaking change
- [ X] Enhancement
- [ ] Fix
- [ X] Documentation
- [ ] Tooling
