### PR TITLE
updating json5 dependency causing vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3350,7 +3350,7 @@
         "babylon": "^6.18.0",
         "convert-source-map": "^1.5.1",
         "debug": "^2.6.9",
-        "json5": "^0.5.1",
+        "json5": "^2.2.3",
         "lodash": "^4.17.4",
         "minimatch": "^3.0.4",
         "path-is-absolute": "^1.0.1",
@@ -3366,15 +3366,6 @@
       "dev": true,
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/babel-core/node_modules/json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
       }
     },
     "node_modules/babel-core/node_modules/ms": {


### PR DESCRIPTION
### Description
- Updating json5 from 0.5.1 to 2.2.3 in package-lock.json

### Issue

Issue Link [[Optional](https://github.com/dailymotion/vast-client-js/security/dependabot/21)]

### Type
- [ ] Breaking change
- [ ] Enhancement
- [X] Fix
- [ ] Documentation
- [ ] Tooling
