### PR TITLE
add trackOnce parameter to setProgress

### DIFF
--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -496,7 +496,7 @@ vastTracker.on('pause', () => {
 });
 ```
 
-### setProgress(progress, macros) <a name="setProgress"></a>
+### setProgress(progress, macros, trackOnce) <a name="setProgress"></a>
 
 Sets the duration of the ad and updates the quartiles based on that. This is required for tracking time related events such as `start`, `firstQuartile`, `midpoint`, `thirdQuartile` or `rewind`.
 
@@ -504,6 +504,7 @@ Sets the duration of the ad and updates the quartiles based on that. This is req
 
 - **`progress: Number`** - Current playback time in seconds
 - **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+- **`trackOnce: Boolean`** - Optional parameter. If set to false, quartile events can be triggered again after a 'rewind' situation.
 
 #### Events emitted
 

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -177,7 +177,7 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#midpoint
    * @emits VASTTracker#thirdQuartile
    */
-  setProgress(progress, macros = {}) {
+  setProgress(progress, macros = {}, trackOnce = true) {
     // check if progress is a valid time input
     if (!util.isValidTimeValue(progress) || typeof macros !== 'object') {
       return;
@@ -213,7 +213,7 @@ export class VASTTracker extends EventEmitter {
         this.lastPercentage = percent;
       }
       events.forEach((eventName) => {
-        this.track(eventName, { macros, once: true });
+        this.track(eventName, { macros, once: trackOnce });
       });
 
       if (progress < this.progress) {

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -130,6 +130,25 @@ describe('VASTTracker', function () {
         });
       });
 
+      describe('#setProgress trackOnce', () => {
+
+        after(()=> {
+          this.stub?.restore();
+        })
+
+        it('should send firstQuartile event with trackOnce : false', () => {
+          this.stub = sinon.stub(this.Tracker, 'track').callsFake((eventName, params) => {
+            console.log("testprogress : "+eventName);
+            if(eventName === 'progress-23') {
+              params.once.should.equal(false);
+              
+            }
+          });
+
+          this.Tracker.setProgress(23, null, false);
+        });
+      });
+
       describe('#setMuted', () => {
         before((done) => {
           _eventsSent = [];

--- a/test/vast_tracker.js
+++ b/test/vast_tracker.js
@@ -130,25 +130,6 @@ describe('VASTTracker', function () {
         });
       });
 
-      describe('#setProgress trackOnce', () => {
-
-        after(()=> {
-          this.stub?.restore();
-        })
-
-        it('should send firstQuartile event with trackOnce : false', () => {
-          this.stub = sinon.stub(this.Tracker, 'track').callsFake((eventName, params) => {
-            console.log("testprogress : "+eventName);
-            if(eventName === 'progress-23') {
-              params.once.should.equal(false);
-              
-            }
-          });
-
-          this.Tracker.setProgress(23, null, false);
-        });
-      });
-
       describe('#setMuted', () => {
         before((done) => {
           _eventsSent = [];


### PR DESCRIPTION
### Description

add a parameter in VASTTracker.setProgress()
to avoid sending event once for all in case we want to send quartile events several times.

### Issue

[Issue Link : issues/460](https://github.com/dailymotion/vast-client-js/issues/460)

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
