### PR TITLE
Fix/fix setMuted object destructuring argument

### DIFF
--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -250,7 +250,7 @@ export class VASTTracker extends EventEmitter {
    * @emits VASTTracker#mute
    * @emits VASTTracker#unmute
    */
-  setMuted(muted, macros = {}) {
+  setMuted(muted, {macros = {}}) {
     if (typeof muted !== 'boolean' || typeof macros !== 'object') {
       return;
     }


### PR DESCRIPTION
### Description

Replace macros parameter with a destructured object in setMuted function

### Issue

Macros parameter was not correct in setMuted function of vast tracker.

### Type
- [ ] Breaking change
- [ ] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
