### PR TITLE
Add raw XML string to url handler callback

### DIFF
--- a/src/urlhandlers/node_url_handler.js
+++ b/src/urlhandlers/node_url_handler.js
@@ -34,6 +34,7 @@ function get(url, options, cb) {
         cb(null, xml, {
           byteLength: Buffer.from(data).byteLength,
           statusCode: res.statusCode,
+          rawXml: data,
         });
       });
     });


### PR DESCRIPTION
### Description

Include the raw XML string in the `details` object returned by node URL handler.

We would like to use this for debugging purposes.

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
