### PR TITLE
fix bug where fallback was not working if first ad element return empty

### DIFF
--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -458,7 +458,7 @@ export class VASTParser extends EventEmitter {
     return Promise.all(resolveWrappersPromises).then((unwrappedAds) => {
       const resolvedAds = util.flatten(unwrappedAds);
 
-      if (!resolvedAds && this.remainingAds.length > 0) {
+      if (!resolvedAds.length && this.remainingAds.length > 0) {
         const remainingAdsToResolve = this.remainingAds.shift();
 
         return this.resolveAds(remainingAdsToResolve, {


### PR DESCRIPTION
### Description

https://github.com/dailymotion/vast-client-js/blob/master/src/parser/vast_parser.js#L461C25-L461C25

The condition will never be reach since `!resolvedAds` will always be `false`.
So in case the first Ad element of a VAST is empty or it fails, it will never fallback to the next Ad element.

### Issue

If any Ad element (going from top to bottom) fails to fetch xml or return empty vast, it will not fallback to next Ad Element.

[Issue Link](https://github.com/dailymotion/vast-client-js/issues/465
)

### Type
- [ ] Breaking change
- [ ] Enhancement
- [X] Fix
- [ ] Documentation
- [ ] Tooling
