### PR TITLE
AbortHandler's timeout should always be cleared

### DIFF
--- a/src/fetcher/url_handler.js
+++ b/src/fetcher/url_handler.js
@@ -66,8 +66,10 @@ async function get(url, options) {
       ...options,
       signal: controller.signal,
       credentials: options.withCredentials ? 'include' : 'omit',
+    })
+    .finally(()=>{
+      clearTimeout(timer);
     });
-    clearTimeout(timer);
 
     const error = handleError(response);
     if (error) {


### PR DESCRIPTION
the timeout should always be cleared even if an error occurred within the promise

### Description

When you provide a custom urlHandler and an error occurs here-in it could be possible the abortHandlers timeout isn't cleared, causing the abortHandler to trigger even if the request is done.


### Type
- [ x] Fix
