### PR TITLE
Fix issue where ads where merged if the first ad was empty

### DIFF
--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -286,6 +286,7 @@ export class VASTParser extends EventEmitter {
     - Inline sequence 2,
     - Inline sequence 3
   */
+
     if (
       ads.length === 1 &&
       wrapperSequence !== undefined &&
@@ -329,19 +330,7 @@ export class VASTParser extends EventEmitter {
     });
 
     return Promise.all(resolveWrappersPromises).then((unwrappedAds) => {
-      const resolvedAds = util.flatten(unwrappedAds);
-
-      if (!resolvedAds.length && this.remainingAds.length > 0) {
-        const remainingAdsToResolve = this.remainingAds.shift();
-
-        return this.resolveAds(remainingAdsToResolve, {
-          wrapperDepth,
-          previousUrl,
-          url,
-        });
-      }
-
-      return resolvedAds;
+      return util.flatten(unwrappedAds);
     });
   }
 


### PR DESCRIPTION
### Description

fix issue where ads where merged if the first ad was empty

### Issue

When using the vast-client version 6, we noticed double impressions when using some vasts.

It happened when the resolveAll option of the vast-client is set to false.
All the ad node are merged instead of having only the first one in the final response.

### Type
- [ ] Breaking change
- [ ] Enhancement
- [X] Fix
- [ ] Documentation
- [ ] Tooling
