### PR TITLE
Preserve offset values in progress tracking events parsing

### DIFF
--- a/spec/samples/inline_trackers.js
+++ b/spec/samples/inline_trackers.js
@@ -191,6 +191,7 @@ export const inlineTrackersParsed = {
             close: ['http://example.com/linear-close'],
             thirdQuartile: ['http://example.com/linear-thirdQuartile'],
             'progress-30': ['http://example.com/linear-progress-30sec'],
+            'progress-42.333': ['http://example.com/linear-progress-42.333sec'],
             'progress-60%': ['http://example.com/linear-progress-60%'],
             otherAdInteraction: [
               'http://example.com/linear-otherAdInteraction',

--- a/spec/vast_tracker.spec.js
+++ b/spec/vast_tracker.spec.js
@@ -523,7 +523,7 @@ describe('VASTTracker', function () {
         expect(spyEmitter).toHaveBeenCalledWith('skip-countdown', 0);
       });
 
-      it('should track rewind  when set to 2', () => {
+      it('should track rewind when set to 2', () => {
         vastTracker.setProgress(2);
         expect(spyTrack).toHaveBeenCalledWith('rewind', expect.any(Object));
       });

--- a/src/parser/creative_linear_parser.js
+++ b/src/parser/creative_linear_parser.js
@@ -105,9 +105,9 @@ export function parseCreativeLinear(creativeElement, creativeAttributes) {
               if (offset.charAt(offset.length - 1) === '%') {
                 eventName = `progress-${offset}`;
               } else {
-                eventName = `progress-${Math.round(
+                eventName = `progress-${
                   parserUtils.parseDuration(offset)
-                )}`;
+                }`;
               }
             }
 


### PR DESCRIPTION
### Description
The precision of Progress tracking events in VAST XML has been improved to preserve the exact offset value in its original format, whether time-based (e.g., 00:00:15.333) or percentage-based (e.g., 60%). The parsing logic has been refined to ensure these values are accurately retained, providing greater reliability and flexibility.

Below is an example showing the improvement:

<img width="447" alt="Capture d’écran 2025-01-08 à 11 39 58" src="https://github.com/user-attachments/assets/0a7fdeec-3880-4212-b86e-9aae89742000" />


### Issue
https://github.com/dailymotion/vast-client-js/issues/485

### Type
- [ ] Breaking change
- [X] Enhancement
- [ ] Fix
- [ ] Documentation
- [ ] Tooling
