### PR TITLE
Fix AdPods parsing behavior with resolveAll to false

### DIFF
--- a/docs/api/vast-client.md
+++ b/docs/api/vast-client.md
@@ -116,7 +116,7 @@ By default the fully parsed `VASTResponse` contains all the Ads contained in the
   - `wrapperLimit: Number` - A number of Wrapper responses that can be received with no InLine response (default `10`)
   - `urlHandler: URLHandler` - Custom urlhandler to be used instead of the default ones [`urlhandlers`](../../src/urlhandlers)
   - `urlhandler: URLHandler` - Fulfills the same purpose as `urlHandler`, which is the preferred parameter to use
-  - `resolveAll: Boolean` - Allows you to parse all the ads contained in the VAST or to parse them ad by ad or adPod by adPod (default `true`)
+  - `resolveAll: Boolean` - Allows you to parse all the ads contained in the VAST or to parse: only the AdPod, or stand alone ad per stand alone ad (default `true`)
   - `allowMultipleAds: Boolean` - A Boolean value that identifies whether multiple ads are allowed in the requested VAST response. This will override any value of allowMultipleAds attribute set in the VAST
   - `followAdditionalWrappers: Boolean` - a Boolean value that identifies whether subsequent Wrappers after a requested VAST response is allowed. This will override any value of followAdditionalWrappers attribute set in the VAST
 
@@ -225,12 +225,13 @@ Using `get` method with default `options` will return a [`VASTResponse`](https:/
 }
 ```
 
-The `resolveAll` parameter allows to request only the first Ad or AdPod. If we pass it as `false` the response would look like:
+The `resolveAll` parameter allows to request only the AdPod or first Ad. If we pass it as `false` the response would look like:
 
 ```Javascript
 {
   ads: [
-    ad1
+    ad2,
+    ad3
   ],
   errorURLTemplates,
   version

--- a/spec/parser_utils.spec.js
+++ b/spec/parser_utils.spec.js
@@ -1,173 +1,69 @@
 import { parserUtils } from '../src/parser/parser_utils.js';
 
 describe('ParserUtils', function () {
-  describe('splitVAST', function () {
-    it('should parse normally defined vast pods', () => {
-      const input = [
-        { id: 2, sequence: 1 },
-        { id: 3, sequence: 2 },
-        { id: 4 },
-        { id: 5, sequence: 1 },
-        { id: 6, sequence: 2 },
-        { id: 7, sequence: 3 },
-        { id: 8, sequence: 1 },
-        { id: 9, sequence: 2 },
-        { id: 10 },
-        { id: 11, sequence: 1 },
-        { id: 12 },
+  describe('getSortedAdPods', function () {
+    it('should return sorted ad pods based on sequence attribute', function () {
+      const ads = [
+        { sequence: '3', id: 'ad3' },
+        { sequence: '1', id: 'ad1' },
+        { sequence: '2', id: 'ad2' },
       ];
-
-      const expectedOutput = [
-        [
-          { id: 2, sequence: 1 },
-          { id: 3, sequence: 2 },
-        ],
-        [{ id: 4 }],
-        [
-          { id: 5, sequence: 1 },
-          { id: 6, sequence: 2 },
-          { id: 7, sequence: 3 },
-        ],
-        [
-          { id: 8, sequence: 1 },
-          { id: 9, sequence: 2 },
-        ],
-        [{ id: 10 }],
-        [{ id: 11, sequence: 1 }],
-        [{ id: 12 }],
-      ];
-
-      const output = parserUtils.splitVAST(input);
-
-      expect(output).toEqual(expectedOutput);
+      const sortedAds = parserUtils.getSortedAdPods(ads);
+      expect(sortedAds).toEqual([
+        { sequence: '1', id: 'ad1' },
+        { sequence: '2', id: 'ad2' },
+        { sequence: '3', id: 'ad3' },
+      ]);
     });
 
-    it('should parse vast pods with single sequence', () => {
-      const input = [
-        { id: 1, sequence: 1 },
-        { id: 2, sequence: 1 },
-        { id: 3, sequence: 1 },
+    it('should filter out ads without sequence attribute', function () {
+      const ads = [
+        { sequence: '3', id: 'ad3' },
+        { id: 'adWithoutSequence' },
+        { sequence: '2', id: 'ad2' },
+        { sequence: '1', id: 'ad1' },
       ];
-
-      const expectedOutput = [
-        [{ id: 1, sequence: 1 }],
-        [{ id: 2, sequence: 1 }],
-        [{ id: 3, sequence: 1 }],
-      ];
-
-      const output = parserUtils.splitVAST(input);
-
-      expect(output).toEqual(expectedOutput);
+      const sortedAds = parserUtils.getSortedAdPods(ads);
+      expect(sortedAds).toEqual([
+        { sequence: '1', id: 'ad1' },
+        { sequence: '2', id: 'ad2' },
+        { sequence: '3', id: 'ad3' },
+      ]);
     });
 
-    it('should parse vast pods with no pods', () => {
-      const input = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    it('should return an empty array if no adPods are provided', function () {
+      const ads = [
+        { id: 'adWithoutSequence1' },
+        { id: 'adWithoutSequence2' },
+        { id: 'adWithoutSequence3' },
+      ];
+      const sortedAds = parserUtils.getSortedAdPods(ads);
+      expect(sortedAds).toEqual([]);
+    });
+  });
 
-      const expectedOutput = [[{ id: 1 }], [{ id: 2 }], [{ id: 3 }]];
-
-      const output = parserUtils.splitVAST(input);
-
-      expect(output).toEqual(expectedOutput);
+  describe('getStandAloneAds', function () {
+    it('should return standalone ads without sequence attribute', function () {
+      const ads = [
+        { sequence: '3', id: 'ad3' },
+        { id: 'adWithoutSequence1' },
+        { sequence: '1', id: 'ad1' },
+        { id: 'adWithoutSequence2' },
+      ];
+      const standAloneAds = parserUtils.getStandAloneAds(ads);
+      expect(standAloneAds).toEqual([
+        { id: 'adWithoutSequence1' },
+        { id: 'adWithoutSequence2' },
+      ]);
     });
 
-    it('should parse vast pods with weird sequences', () => {
-      const input = [
-        { id: 1, sequence: 99 },
-        { id: 2, sequence: 99 },
-        { id: 3, sequence: 99 },
+    it('should return an empty array if all ads have sequence attribute', function () {
+      const ads = [
+        { sequence: '1', id: 'ad1' },
+        { sequence: '2', id: 'ad2' },
       ];
-
-      const expectedOutput = [[{ id: 1 }], [{ id: 2 }], [{ id: 3 }]];
-
-      const output = parserUtils.splitVAST(input);
-
-      expect(output).toEqual(expectedOutput);
-    });
-
-    it('should parse vast pods with sequences that not start with index = 1', () => {
-      const input = [
-        { id: 1, sequence: 2 },
-        { id: 4 },
-        { id: 98, sequence: 3 },
-        { id: 99, sequence: 4 },
-        { id: 5, sequence: 1 },
-        { id: 6, sequence: 2 },
-        { id: 7, sequence: 3 },
-        { id: 8, sequence: 1 },
-        { id: 9, sequence: 2 },
-        { id: 10 },
-        { id: 11, sequence: 1 },
-        { id: 12 },
-      ];
-
-      const expectedOutput = [
-        [{ id: 1 }],
-        [{ id: 4 }],
-        [{ id: 98 }],
-        [{ id: 99 }],
-        [
-          { id: 5, sequence: 1 },
-          { id: 6, sequence: 2 },
-          { id: 7, sequence: 3 },
-        ],
-        [
-          { id: 8, sequence: 1 },
-          { id: 9, sequence: 2 },
-        ],
-        [{ id: 10 }],
-        [{ id: 11, sequence: 1 }],
-        [{ id: 12 }],
-      ];
-
-      const output = parserUtils.splitVAST(input);
-
-      expect(output).toEqual(expectedOutput);
-    });
-
-    it('should parse vast pods with sequences that not start with index = 1, and not following incrementally', () => {
-      const input = [
-        { id: 1, sequence: 2 },
-        { id: 2, sequence: 4 },
-        { id: 4 },
-        { id: 98, sequence: 3 },
-        { id: 99, sequence: 4 },
-        { id: 100, sequence: 17 },
-        { id: 101, sequence: 18 },
-        { id: 5, sequence: 1 },
-        { id: 6, sequence: 2 },
-        { id: 7, sequence: 3 },
-        { id: 8, sequence: 1 },
-        { id: 9, sequence: 2 },
-        { id: 10 },
-        { id: 11, sequence: 1 },
-        { id: 12 },
-      ];
-
-      const expectedOutput = [
-        [{ id: 1 }],
-        [{ id: 2 }],
-        [{ id: 4 }],
-        [{ id: 98 }],
-        [{ id: 99 }],
-        [{ id: 100 }],
-        [{ id: 101 }],
-        [
-          { id: 5, sequence: 1 },
-          { id: 6, sequence: 2 },
-          { id: 7, sequence: 3 },
-        ],
-        [
-          { id: 8, sequence: 1 },
-          { id: 9, sequence: 2 },
-        ],
-        [{ id: 10 }],
-        [{ id: 11, sequence: 1 }],
-        [{ id: 12 }],
-      ];
-
-      const output = parserUtils.splitVAST(input);
-
-      expect(output).toEqual(expectedOutput);
+      const standAloneAds = parserUtils.getStandAloneAds(ads);
+      expect(standAloneAds).toEqual([]);
     });
   });
 

--- a/spec/vast_client.spec.js
+++ b/spec/vast_client.spec.js
@@ -118,20 +118,17 @@ describe('VASTClient', () => {
           optionsWithNoResolveAll
         );
       });
-      it('returns first ad parsed', () => {
-        expect(res).toEqual({
-          ads: expect.any(Array),
-          errorURLTemplates: [],
-          version: '4.3',
-        });
+      it('returns ad pod parsed', () => {
         expect(res.ads).toHaveLength(2);
+        expect(res.ads[0].sequence).toBe('1');
+        expect(res.ads[1].sequence).toBe('2');
       });
 
-      it('should return only the errorURLs for the first ad', () => {
-        expect(res.ads[0].errorURLTemplates).toEqual([
-          'http://example.com/error',
-          'http://example.com/error_[ERRORCODE]',
-        ]);
+      it('should return stand alone ads in the remaining ads', () => {
+        const remainingAds = VastClient.getParser().remainingAds;
+        expect(remainingAds[0].id).toBe('201');
+        expect(remainingAds[0].id).toBe('2032');
+        expect(remainingAds.length).toBe(2);
       });
 
       it('handles empty ads correctly', async () => {
@@ -161,7 +158,7 @@ describe('VASTClient', () => {
           expect(res.ads).toHaveLength(3);
         });
 
-        it('resolves only next ad if requested', async () => {
+        fit('resolves only next ad if requested', async () => {
           await VastClient.get(
             wrapperMultipleAdsVastUrl,
             optionsWithNoResolveAll

--- a/spec/vast_client.spec.js
+++ b/spec/vast_client.spec.js
@@ -127,26 +127,13 @@ describe('VASTClient', () => {
       it('should return stand alone ads in the remaining ads', () => {
         const remainingAds = VastClient.getParser().remainingAds;
         expect(remainingAds[0].id).toBe('201');
-        expect(remainingAds[0].id).toBe('2032');
+        expect(remainingAds[1].id).toBe('2032');
         expect(remainingAds.length).toBe(2);
-      });
-
-      it('handles empty ads correctly', async () => {
-        const response = await VastClient.get(
-          emptyVastUrl,
-          optionsWithNoResolveAll
-        );
-        expect(response).toEqual({
-          ads: [],
-          errorURLTemplates: ['http://example.com/empty-no-ad'],
-          version: '4.3',
-        });
       });
 
       it('returns true for hasRemainingAds', () => {
         expect(VastClient.hasRemainingAds()).toBeTruthy();
       });
-
       describe('getNextAds', () => {
         it('resolves all next ads if requested', async () => {
           const res = await VastClient.getNextAds(true);
@@ -158,7 +145,7 @@ describe('VASTClient', () => {
           expect(res.ads).toHaveLength(3);
         });
 
-        fit('resolves only next ad if requested', async () => {
+        it('resolves only next ad if requested', async () => {
           await VastClient.get(
             wrapperMultipleAdsVastUrl,
             optionsWithNoResolveAll
@@ -170,6 +157,18 @@ describe('VASTClient', () => {
             version: '4.3',
           });
           expect(response.ads).toHaveLength(2);
+        });
+      });
+
+      it('handles empty ads correctly', async () => {
+        const response = await VastClient.get(
+          emptyVastUrl,
+          optionsWithNoResolveAll
+        );
+        expect(response).toEqual({
+          ads: [],
+          errorURLTemplates: ['http://example.com/empty-no-ad'],
+          version: '4.3',
         });
       });
     });

--- a/src/parser/parser_utils.js
+++ b/src/parser/parser_utils.js
@@ -138,37 +138,23 @@ export function parseDuration(durationString) {
 }
 
 /**
- * Splits an Array of ads into an Array of Arrays of ads.
- * Each subarray contains either one ad or multiple ads (an AdPod)
- * @param  {Array} ads - An Array of ads to split
- * @return {Array}
+ * Sorts and filters ads that are part of an Ad Pod.
+ * @param {Array} ads - An array of ad objects.
+ * @returns {Array} An array of sorted ad objects based on the sequence attribute.
  */
-function splitVAST(ads) {
-  const splittedVAST = [];
-  let lastAdPod = null;
+function getSortedAdPods(ads = []) {
+  return ads
+    .filter((ad) => parseInt(ad.sequence, 10))
+    .sort((a, b) => a.sequence - b.sequence);
+}
 
-  ads.forEach((ad, i) => {
-    if (ad.sequence) {
-      ad.sequence = parseInt(ad.sequence, 10);
-    }
-    // The current Ad may be the next Ad of an AdPod
-    if (ad.sequence > 1) {
-      const lastAd = ads[i - 1];
-      // check if the current Ad is exactly the next one in the AdPod
-      if (lastAd && lastAd.sequence === ad.sequence - 1) {
-        lastAdPod && lastAdPod.push(ad);
-        return;
-      }
-      // If the ad had a sequence attribute but it was not part of a correctly formed
-      // AdPod, let's remove the sequence attribute
-      delete ad.sequence;
-    }
-
-    lastAdPod = [ad];
-    splittedVAST.push(lastAdPod);
-  });
-
-  return splittedVAST;
+/**
+ * Filters out AdPods of given ads array and returns only standalone ads without sequence attribute.
+ * @param {Array} ads - An array of ad objects.
+ * @returns {Array} An array of standalone ad.
+ */
+function getStandAloneAds(ads = []) {
+  return ads.filter((ad) => !parseInt(ad.sequence, 10));
 }
 
 /**
@@ -343,7 +329,8 @@ export const parserUtils = {
   copyNodeAttribute,
   parseAttributes,
   parseDuration,
-  splitVAST,
+  getStandAloneAds,
+  getSortedAdPods,
   assignAttributes,
   mergeWrapperAdData,
 };

--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -237,7 +237,6 @@ export class VASTParser extends EventEmitter {
         }
       }
     }
-
     return ads;
   }
 
@@ -304,7 +303,12 @@ export class VASTParser extends EventEmitter {
       const adPods = parserUtils.getSortedAdPods(ads);
       const standAloneAds = parserUtils.getStandAloneAds(ads);
       // Resolve only AdPod found first, if no AdPod found resolve only the first stand alone Ad
-      ads = adPods.length ? adPods : [standAloneAds.shift()];
+      if (adPods.length) {
+        ads = adPods;
+      } else if (standAloneAds.length) {
+        ads = [standAloneAds.shift()];
+      }
+
       this.remainingAds = standAloneAds;
     }
 

--- a/src/parser/vast_parser.js
+++ b/src/parser/vast_parser.js
@@ -96,10 +96,7 @@ export class VASTParser extends EventEmitter {
         new Error('No more ads are available for the given VAST')
       );
     }
-
-    const ads = all
-      ? util.flatten(this.remainingAds)
-      : this.remainingAds.shift();
+    const ads = all ? this.remainingAds : [this.remainingAds.shift()];
     this.errorURLTemplates = [];
 
     return this.resolveAds(ads, {
@@ -303,12 +300,12 @@ export class VASTParser extends EventEmitter {
     ) {
       ads[0].sequence = wrapperSequence;
     }
-
-    // Split the VAST in case we don't want to resolve everything at the first time
     if (resolveAll === false) {
-      this.remainingAds = parserUtils.splitVAST(ads);
-      // Remove the first element from the remaining ads array, since we're going to resolve that element
-      ads = this.remainingAds.shift();
+      const adPods = parserUtils.getSortedAdPods(ads);
+      const standAloneAds = parserUtils.getStandAloneAds(ads);
+      // Resolve only AdPod found first, if no AdPod found resolve only the first stand alone Ad
+      ads = adPods.length ? adPods : [standAloneAds.shift()];
+      this.remainingAds = standAloneAds;
     }
 
     return this.resolveAds(ads, {


### PR DESCRIPTION
### Description
Previously, when a VAST contained an adPod with standalone ads, if a standalone ad appeared first in the VAST order, it would be parsed first, causing the adPod to not be resolved. As a result, the Player couldn't be aware that the VAST contained an adPod. According to IAB specifications, the adPod should take priority and play before any standalone ads. This PR addresses the issue by ensuring that the adPod is resolved first, followed by the standalone ads, when `getNextAds` is called.

### Issue
[#360](https://github.com/dailymotion/vast-client-js/issues/360)

### Type
- [ ] Breaking change
- [x] Enhancement
- [x] Fix
- [ ] Documentation
- [ ] Tooling
