### PR TITLE
[client][test] Add ability to pass extra options to fetch method

### DIFF
--- a/docs/api/vast-client.md
+++ b/docs/api/vast-client.md
@@ -113,6 +113,7 @@ By default the fully parsed `VASTResponse` contains all the Ads contained in the
 - **`options: Object`** - An optional Object to configure the request:
   - `timeout: Number` - A custom timeout for the requests (default `120000 ms`)
   - `withCredentials: Boolean` - A boolean to enable the withCredentials options for the XHR URLHandler (default `false`)
+  - `fetchOptions: Object` - Additional options to pass to the fetch request, like headers, cache, etc.
   - `wrapperLimit: Number` - A number of Wrapper responses that can be received with no InLine response (default `10`)
   - `urlHandler: URLHandler` - Custom urlhandler to be used instead of the default ones [`urlhandlers`](../../src/urlhandlers)
   - `urlhandler: URLHandler` - Fulfills the same purpose as `urlHandler`, which is the preferred parameter to use
@@ -136,7 +137,13 @@ vastClient.get('http://example.dailymotion.com/vast.xml')
 // With the options optional parameter
 const options = {
   withCredentials: true,
-  wrapperLimit: 7
+  wrapperLimit: 7,
+  fetchOptions: {
+    headers: {
+      'User-Agent': 'My Custom User Agent',
+      'Cache-Control': 'no-cache'
+    }
+  }
 };
 
 vastClient.get('http://example.dailymotion.com/vast.xml', options)
@@ -161,6 +168,7 @@ If you just need to parse an inline VAST or you want to parse the first VAST doc
 - **`options: Object`** - An optional Object of parameters to be used in the parsing process
   - `timeout: Number` - A custom timeout for the possible wrapper resolving requests (default `120000`)
   - `withCredentials: Boolean` - A boolean to enable the withCredentials options for the XHR URLHandler (default `false`)
+  - `fetchOptions: Object` - Additional options to pass to the fetch request, like headers, cache, etc.
   - `wrapperLimit: Number` - A number of Wrapper responses that can be received with no InLine response (default `10`)
   - `urlHandler: URLHandler` - Custom urlhandler to be used instead of the default ones [`urlhandlers`](../../src/urlhandlers)
   - `urlhandler: URLHandler` - Fulfills the same purpose as `urlHandler`, which is the preferred parameter to use

--- a/spec/fetcher.spec.js
+++ b/spec/fetcher.spec.js
@@ -44,7 +44,7 @@ describe('Fetcher', () => {
         const expectedUrl = 'www.bar.foo';
 
         fetcher
-          .fetchVAST({ url: url, maxWrapperDepth: 5, emitter: () => {} })
+          .fetchVAST({ url: url, maxWrapperDepth: 5, emitter: () => { } })
           .then(() => {
             expect(urlHandlerSpy).toHaveBeenCalledWith(
               expectedUrl,
@@ -87,7 +87,7 @@ describe('Fetcher', () => {
       it('should updates the estimated bitrate', () => {
         jest.spyOn(Bitrate, 'updateEstimatedBitrate');
         fetcher
-          .fetchVAST({ url: url, maxWrapperDepth: 5, emitter: () => {} })
+          .fetchVAST({ url: url, maxWrapperDepth: 5, emitter: () => { } })
           .then(() => {
             expect(Bitrate.updateEstimatedBitrate).toHaveBeenCalledWith(
               1234,
@@ -100,7 +100,7 @@ describe('Fetcher', () => {
         let result = fetcher.fetchVAST({
           url: url,
           maxWrapperDepth: 5,
-          emitter: () => {},
+          emitter: () => { },
         });
         return expect(result).resolves.toEqual(xml);
       });
@@ -120,7 +120,7 @@ describe('Fetcher', () => {
         const expectedUrl = 'www.bar.foo';
 
         fetcher
-          .fetchVAST({ url: url, maxWrapperDepth: 5, emitter: () => {} })
+          .fetchVAST({ url: url, maxWrapperDepth: 5, emitter: () => { } })
           .catch(() => {
             expect(urlHandlerSpy).toHaveBeenCalledWith(
               expectedUrl,
@@ -173,7 +173,7 @@ describe('Fetcher', () => {
         let result = fetcher.fetchVAST({
           url: url,
           maxWrapperDepth: 5,
-          emitter: () => {},
+          emitter: () => { },
         });
         return expect(result).rejects.toEqual({
           error: new Error('AbortError'),
@@ -201,6 +201,43 @@ describe('Fetcher', () => {
       expect(fetcher.urlHandler).toEqual(urlHandler);
       expect(fetcher.fetchingOptions.timeout).toEqual(120000);
       expect(fetcher.fetchingOptions.withCredentials).toEqual(false);
+    });
+
+    it('should spread fetchOptions into fetchingOptions', () => {
+      const fetchOptions = {
+        headers: {
+          'User-Agent': 'Custom User Agent',
+          'Cache-Control': 'no-cache',
+        },
+        cache: 'no-store',
+      };
+
+      fetcher.setOptions({
+        fetchOptions,
+      });
+
+      expect(fetcher.fetchingOptions.headers).toEqual(fetchOptions.headers);
+      expect(fetcher.fetchingOptions.cache).toEqual(fetchOptions.cache);
+    });
+
+    it('should not override timeout and withCredentials when using fetchOptions', () => {
+      const fetchOptions = {
+        timeout: 30000,
+        withCredentials: false,
+        headers: {
+          'User-Agent': 'Custom User Agent',
+        },
+      };
+
+      fetcher.setOptions({
+        timeout: 60000,
+        withCredentials: true,
+        fetchOptions,
+      });
+
+      expect(fetcher.fetchingOptions.timeout).toEqual(60000);
+      expect(fetcher.fetchingOptions.withCredentials).toEqual(true);
+      expect(fetcher.fetchingOptions.headers).toEqual(fetchOptions.headers);
     });
   });
 

--- a/src/fetcher/fetcher.js
+++ b/src/fetcher/fetcher.js
@@ -20,6 +20,7 @@ export class Fetcher {
   setOptions(options = {}) {
     this.urlHandler = options.urlHandler || options.urlhandler || urlHandler;
     this.fetchingOptions = {
+      ...options.fetchOptions,
       timeout: options.timeout || DEFAULT_TIMEOUT,
       withCredentials: Boolean(options.withCredentials),
     };


### PR DESCRIPTION
### Description

Enhance VAST client options to include `fetchOptions` for custom request body `fetchingOptions` like headers and caching. This is helpful when you want to pass basic params but don't want to write a whole urlHandler.
Update tests to validate fetchOptions integration and ensure existing timeout and withCredentials settings are preserved.

### Type
- [ ] Breaking change
- [x] Enhancement
- [ ] Fix
- [x] Documentation
- [ ] Tooling
