### PR TITLE
[tracker] add once feature to viewableImpression tracking

### DIFF
--- a/docs/api/vast-tracker.md
+++ b/docs/api/vast-tracker.md
@@ -624,7 +624,9 @@ This method should be used when the ad meets criteria for Viewable impression as
 
 #### Parameters
 
-- - **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+- **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+- **`once: Boolean`** - An optional Boolean to define if the event has to be tracked only once. Set to `false` by default
+
 
 #### Event emitted
 
@@ -650,7 +652,9 @@ This method should be used when the ad meets criteria for NotViewable impression
 
 #### Parameters
 
-- - **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+- **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+- **`once: Boolean`** - An optional Boolean to define if the event has to be tracked only once. Set to `false` by default
+
 
 #### Event emitted
 
@@ -676,7 +680,9 @@ This method should be used when the ad meets criteria for ViewUndetermined impre
 
 #### Parameters
 
-- - **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+- **`macros: Object`** - Optional parameter. Object containing macros and their values to be replaced. Macros must be supported by VAST specification.
+- **`once: Boolean`** - An optional Boolean to define if the event has to be tracked only once. Set to `false` by default
+
 
 #### Event emitted
 

--- a/spec/vast_tracker.spec.js
+++ b/spec/vast_tracker.spec.js
@@ -851,6 +851,16 @@ describe('VASTTracker', function () {
             message: `trackViewableImpression given macros has the wrong type. macros: ${wrongTrackerValue}`,
           });
         });
+
+        it('should not call Viewable URLs if already called', () => {
+          vastTracker.trackViewableImpression(macros, true);
+          vastTracker.trackViewableImpression(macros, true);
+          expect(spyTrackUrl).toHaveBeenCalledWith(
+            ['http://example.com/viewable', 'http://example.com/viewable2'],
+            macros
+          );
+          expect(spyTrackUrl).toHaveBeenCalledTimes(1);
+        });
       });
 
       describe('#trackNotViewableImpression', () => {
@@ -871,6 +881,19 @@ describe('VASTTracker', function () {
             message: `trackNotViewableImpression given macros has the wrong type. macros: ${wrongTrackerValue}`,
           });
         });
+
+        it('should not call NotViewable URLs if already called', () => {
+          vastTracker.trackNotViewableImpression(macros, true);
+          vastTracker.trackNotViewableImpression(macros, true);
+          expect(spyTrackUrl).toHaveBeenCalledWith(
+            [
+              'http://example.com/notviewable',
+              'http://example.com/notviewable2',
+            ],
+            macros
+          );
+          expect(spyTrackUrl).toHaveBeenCalledTimes(1);
+        });
       });
 
       describe('#trackUndeterminedImpression', () => {
@@ -890,6 +913,19 @@ describe('VASTTracker', function () {
           expect(spyEmitter).toHaveBeenCalledWith('TRACKER-error', {
             message: `trackUndeterminedImpression given macros has the wrong type. macros: ${wrongTrackerValue}`,
           });
+        });
+
+        it('should not call ViewUndetermined URLs if already called', () => {
+          vastTracker.trackUndeterminedImpression(macros, true);
+          vastTracker.trackUndeterminedImpression(macros, true);
+          expect(spyTrackUrl).toHaveBeenCalledWith(
+            [
+              'http://example.com/undertermined',
+              'http://example.com/undertermined2',
+            ],
+            macros
+          );
+          expect(spyTrackUrl).toHaveBeenCalledTimes(1);
         });
       });
     });

--- a/src/vast_tracker.js
+++ b/src/vast_tracker.js
@@ -77,7 +77,7 @@ export class VASTTracker extends EventEmitter {
           return accumulator;
         },
         { notViewable: [], viewUndetermined: [], viewable: [] }
-      ) || [];
+      ) || {};
 
     Object.entries(this.viewableImpressionTrackers).forEach(([key, value]) => {
       if (value.length) this.trackingEvents[key] = value;


### PR DESCRIPTION
### Description

Currently, there is no solution provided by the vast tracker to call a ViewableImpression tracker only once like other tracking events. This is because the <ViewableImpression> node parent is the <Ad> node and not <Creative> like for <TrackingEvents> node. 

This PR add the once parameter to achieve that. 

 
